### PR TITLE
New agents lesson for QB2, packaging fixes

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -69,13 +69,15 @@ CLAUDE.md
 .secretlintignore
 
 # ═══════════════════════════════════════════════════════════════════════════════
-# Source content / theme directories
+# Source content / theme / asset directories
 #
-# Both are copied into dist/ by the copy-content build step. Shipping the
+# All are copied into dist/ by the copy-content build step. Shipping the
 # originals alongside dist/ doubles the file count for no benefit.
-# The extension references dist/content/ and dist/themes/ at runtime.
+# The extension references dist/content/, dist/themes/, and dist/assets/ at
+# runtime. assets/ stays in the repo for GitHub/gh-pages image rendering.
 # ═══════════════════════════════════════════════════════════════════════════════
 
+assets/
 content/
 themes/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.400] - 2026-04-21
+
+### Fixed
+- **`assets/img/` no longer packaged twice in the `.vsix`**: `ImagePreviewViewProvider` now references `dist/assets/img/` (consistent with all other webviews) instead of the repo-root `assets/img/` directory. Added `assets/` to `.vscodeignore` so only `dist/assets/` ships with the extension. `assets/img/` remains in the repo untouched for GitHub and gh-pages image rendering.
+
+---
+
 ## [0.0.370] - 2026-04-17
 
 ### Fixed

--- a/content/lesson-registry.json
+++ b/content/lesson-registry.json
@@ -1,73 +1,73 @@
 {
   "version": "1.0.0",
-  "_warning": "⚠️  PARTIALLY AUTO-GENERATED - Source of truth: Markdown front matter in content/lessons/*.md. Fields like id, title, description, category, tags, supportedHardware, status, validatedOn, estimatedMinutes MUST match markdown. Fields like order, previousLesson, nextLesson, completionEvents are manually maintained here. Run 'npm run validate:lessons' to check sync. See CLAUDE.md for workflow.",
+  "_warning": "\u26a0\ufe0f  PARTIALLY AUTO-GENERATED - Source of truth: Markdown front matter in content/lessons/*.md. Fields like id, title, description, category, tags, supportedHardware, status, validatedOn, estimatedMinutes MUST match markdown. Fields like order, previousLesson, nextLesson, completionEvents are manually maintained here. Run 'npm run validate:lessons' to check sync. See CLAUDE.md for workflow.",
   "categories": [
     {
       "id": "welcome",
-      "title": "👋 Your journey begins here",
+      "title": "\ud83d\udc4b Your journey begins here",
       "description": "Get started with resources and documentation",
       "order": 1,
       "icon": "home"
     },
     {
       "id": "first-inference",
-      "title": "🚀 Your First Inference",
+      "title": "\ud83d\ude80 Your First Inference",
       "description": "Set up hardware and run your first model",
       "order": 2,
       "icon": "rocket"
     },
     {
       "id": "serving",
-      "title": "🏭 Serving Models",
+      "title": "\ud83c\udfed Serving Models",
       "description": "Production deployment and serving infrastructure",
       "order": 3,
       "icon": "server"
     },
     {
       "id": "compilers",
-      "title": "🔧 Compilers & Tools",
+      "title": "\ud83d\udd27 Compilers & Tools",
       "description": "TT-Forge, TT-XLA, and compiler toolchains",
       "order": 4,
       "icon": "tools"
     },
     {
       "id": "applications",
-      "title": "🎯 Applications",
+      "title": "\ud83c\udfaf Applications",
       "description": "Build real-world applications with AI",
       "order": 5,
       "icon": "lightbulb"
     },
     {
       "id": "advanced",
-      "title": "🎓 Advanced Topics",
+      "title": "\ud83c\udf93 Advanced Topics",
       "description": "Low-level programming, installation, and community contributions",
       "order": 6,
       "icon": "mortar-board"
     },
     {
       "id": "custom-training",
-      "title": "🎓 Custom Training",
+      "title": "\ud83c\udf93 Custom Training",
       "description": "Fine-tune and train custom AI models on Tenstorrent hardware",
       "order": 7,
       "icon": "graduation-cap"
     },
     {
       "id": "deployment",
-      "title": "☁️ Deployment",
+      "title": "\u2601\ufe0f Deployment",
       "description": "Deploy your applications to cloud platforms",
       "order": 8,
       "icon": "cloud"
     },
     {
       "id": "cookbook",
-      "title": "👨‍🍳 Tenstorrent Cookbook",
+      "title": "\ud83d\udc68\u200d\ud83c\udf73 Tenstorrent Cookbook",
       "description": "Learn by building! 5 hands-on projects: Game of Life, Audio Processing, Mandelbrot Fractals, Image Filters, and Particle Life",
       "order": 9,
       "icon": "beaker"
     },
     {
       "id": "cs-fundamentals",
-      "title": "🧠 CS Fundamentals",
+      "title": "\ud83e\udde0 CS Fundamentals",
       "description": "Computer architecture, memory, parallelism, and systems programming on real hardware",
       "order": 10,
       "icon": "circuit-board"
@@ -139,7 +139,7 @@
     {
       "id": "verify-installation",
       "title": "Verify Your Setup",
-      "description": "Check that your Tenstorrent hardware, TTNN, and optional tt-metal source are ready before running your first model. A diagnostic checkpoint — returns you here after any setup work.",
+      "description": "Check that your Tenstorrent hardware, TTNN, and optional tt-metal source are ready before running your first model. A diagnostic checkpoint \u2014 returns you here after any setup work.",
       "category": "first-inference",
       "tags": [
         "installation"
@@ -170,7 +170,7 @@
     {
       "id": "download-model",
       "title": "Download Model and Run Inference",
-      "description": "Download Qwen3-0.6B (the recommended model — no license gate, works on all hardware) from Hugging Face to run AI workloads on your Tenstorrent hardware. Optionally download Llama-3.1-8B-Instruct for N300+ hardware.",
+      "description": "Download Qwen3-0.6B (the recommended model \u2014 no license gate, works on all hardware) from Hugging Face to run AI workloads on your Tenstorrent hardware. Optionally download Llama-3.1-8B-Instruct for N300+ hardware.",
       "category": "first-inference",
       "tags": [
         "hardware",
@@ -267,7 +267,7 @@
     {
       "id": "tt-inference-server",
       "title": "Production Inference with tt-inference-server",
-      "description": "Deploy Llama-3.1-8B on any Tenstorrent hardware in minutes — N150, N300, T3K, P100, p300c, or QB2. tt-inference-server automates Docker image selection, model download, and server startup with a single command. OpenAI-compatible API ready immediately.",
+      "description": "Deploy Llama-3.1-8B on any Tenstorrent hardware in minutes \u2014 N150, N300, T3K, P100, p300c, or QB2. tt-inference-server automates Docker image selection, model download, and server startup with a single command. OpenAI-compatible API ready immediately.",
       "category": "serving",
       "tags": [
         "production",
@@ -401,7 +401,7 @@
     {
       "id": "coding-assistant",
       "title": "Coding Assistant with Aider",
-      "description": "Run a real AI coding assistant (Aider) against your local Tenstorrent vLLM server. One install, one command — then pair-program with your own on-device LLM. Also covers prompt engineering to customize behavior.",
+      "description": "Run a real AI coding assistant (Aider) against your local Tenstorrent vLLM server. One install, one command \u2014 then pair-program with your own on-device LLM. Also covers prompt engineering to customize behavior.",
       "category": "applications",
       "tags": [
         "coding",
@@ -848,7 +848,7 @@
     {
       "id": "cookbook-particle-life",
       "title": "Recipe 5: Particle Life Simulator",
-      "description": "Simulate emergent complexity from simple particle interactions! Features N² force calculations, multi-species dynamics, and multi-device acceleration for QuietBox systems. Beautiful chaos from simple physics!",
+      "description": "Simulate emergent complexity from simple particle interactions! Features N\u00b2 force calculations, multi-species dynamics, and multi-device acceleration for QuietBox systems. Beautiful chaos from simple physics!",
       "category": "cookbook",
       "tags": [
         "ttnn",
@@ -880,7 +880,7 @@
     {
       "id": "forge-image-classification",
       "title": "Image Classification with TT-Forge",
-      "description": "Compile a PyTorch MobileNetV2 model for Tenstorrent hardware using forge.compile() — no build required. The forge env is pre-installed: one command to activate, then classify images on real TT silicon.",
+      "description": "Compile a PyTorch MobileNetV2 model for Tenstorrent hardware using forge.compile() \u2014 no build required. The forge env is pre-installed: one command to activate, then classify images on real TT silicon.",
       "category": "compilers",
       "tags": [
         "hardware",
@@ -914,7 +914,7 @@
     {
       "id": "tt-xla-jax",
       "title": "JAX and PyTorch/XLA on Tenstorrent",
-      "description": "Run JAX and PyTorch/XLA computations directly on TT hardware — no install needed. venv-forge ships pjrt_plugin_tt, JAX 0.7.1, and torch-xla pre-installed. Activate, import, and start dispatching tensors to silicon.",
+      "description": "Run JAX and PyTorch/XLA computations directly on TT hardware \u2014 no install needed. venv-forge ships pjrt_plugin_tt, JAX 0.7.1, and torch-xla pre-installed. Activate, import, and start dispatching tensors to silicon.",
       "category": "compilers",
       "tags": [
         "production",
@@ -1151,7 +1151,7 @@
     {
       "id": "build-tt-metal",
       "title": "Build tt-metal from Source",
-      "description": "Clone and build tt-metal from source. Required for Direct API (Generator API) lessons and for running tt-metal examples directly. QB2 and pre-configured images do not ship with ~/tt-metal — start here if Check 3 in Verify Your Setup failed.",
+      "description": "Clone and build tt-metal from source. Required for Direct API (Generator API) lessons and for running tt-metal examples directly. QB2 and pre-configured images do not ship with ~/tt-metal \u2014 start here if Check 3 in Verify Your Setup failed.",
       "category": "first-inference",
       "tags": [
         "installation",
@@ -1206,7 +1206,7 @@
     {
       "id": "explore-metalium",
       "title": "Exploring TT-Metalium",
-      "description": "Discover what's possible with TT-Metalium! Run TTNN operations immediately, explore the model zoo, and understand the architecture that powers Tenstorrent hardware — from first script to custom kernels.",
+      "description": "Discover what's possible with TT-Metalium! Run TTNN operations immediately, explore the model zoo, and understand the architecture that powers Tenstorrent hardware \u2014 from first script to custom kernels.",
       "category": "advanced",
       "tags": [
         "model",
@@ -1364,7 +1364,7 @@
     {
       "id": "qb2-video-generation",
       "title": "Generating Video on QuietBox 2",
-      "description": "Go from a fresh QB2 to AI-generated video clips in one session — Wan2.2-T2V-A14B on 4× Blackhole chips with a GTK4 GUI and automated prompt generation",
+      "description": "Go from a fresh QB2 to AI-generated video clips in one session \u2014 Wan2.2-T2V-A14B on 4\u00d7 Blackhole chips with a GTK4 GUI and automated prompt generation",
       "category": "applications",
       "tags": [
         "qb2",
@@ -1386,7 +1386,38 @@
       "estimatedMinutes": 90,
       "markdownFile": "content/lessons/qb2-video-generation.md",
       "validationDate": "2026-04-15",
-      "validationNotes": "Full pipeline validated on QB2 (2× P300 cards): vendor setup, patches, Wan2.2-T2V-A14B generation (480×832, 80 frames, ~370 s/clip), SkyReels-1.3B (~28 s/clip), Qwen3-0.6B prompt server. Timing data from April 2026 hardware runs."
+      "validationNotes": "Full pipeline validated on QB2 (2\u00d7 P300 cards): vendor setup, patches, Wan2.2-T2V-A14B generation (480\u00d7832, 80 frames, ~370 s/clip), SkyReels-1.3B (~28 s/clip), Qwen3-0.6B prompt server. Timing data from April 2026 hardware runs.",
+      "nextLesson": "qb2-local-agents"
+    },
+    {
+      "id": "qb2-local-agents",
+      "title": "Local AI Agents on QuietBox 2",
+      "description": "Build real AI agents in pure Python \u2014 web research, codebase navigation, multi-agent pipelines, and stateful text adventures \u2014 all running locally on your QB2's 32B/70B models",
+      "category": "applications",
+      "tags": [
+        "qb2",
+        "p300x2",
+        "agents",
+        "smolagents",
+        "crewai",
+        "openai-agents-sdk",
+        "tool-calling",
+        "32b",
+        "70b",
+        "local-inference"
+      ],
+      "supportedHardware": [
+        "p300x2"
+      ],
+      "status": "validated",
+      "validatedOn": [
+        "p300x2"
+      ],
+      "estimatedMinutes": 60,
+      "markdownFile": "content/lessons/qb2-local-agents.md",
+      "previousLesson": "qb2-video-generation",
+      "validationDate": "2026-04-21",
+      "validationNotes": "All five demo scripts validated on QB2 (p300x2) with Qwen3-32B (hermes parser) and Llama-3.3-70B-Instruct (llama3_json parser). Tool calling confirmed working. Research agent, code explorer, writing pipeline, and dungeon master all produce expected output."
     }
   ]
 }

--- a/content/lessons/qb2-local-agents.md
+++ b/content/lessons/qb2-local-agents.md
@@ -377,14 +377,16 @@ python3 ~/code/tt-agents/01_research_agent.py \
 
 Point this at any directory and ask questions. This is what a local coding assistant looks like at the architectural level — it actually reads your files.
 
+Run it from any project directory and it explores that directory by default:
+
 ```bash
-python3 ~/code/tt-agents/02_code_explorer.py \
-    --dir ~/code/tt-inference-server/workflows
+cd ~/code/tt-agents
+python3 02_code_explorer.py
 ```
 
 [Run Code Explorer](command:tenstorrent.runCodeExplorer)
 
-**Explore your own code:**
+**Point it at a specific directory:**
 
 ```bash
 python3 ~/code/tt-agents/02_code_explorer.py \
@@ -396,40 +398,47 @@ python3 ~/code/tt-agents/02_code_explorer.py \
 
 ```bash
 python3 ~/code/tt-agents/02_code_explorer.py \
-    --dir ~/code/tt-inference-server/workflows \
+    --dir ~/code/tt-agents \
     --compare
 ```
 
-**Sample output:**
+**Sample output** (run from `~/code/tt-agents`):
 
 ```
 ======================================================================
 tt-agents Proof 2: Codebase Explorer (OpenAI Agents SDK)
 ======================================================================
 Endpoint: http://localhost:8000/v1
-Directory: /home/ttuser/code/tt-inference-server/workflows
+Directory: /home/ttuser/code/tt-agents
 
 Query:
-  Which LLM models support P300X2 and what tool parsers do they use?
+  Summarize this codebase, how it is organized, and which files
+  are most important to understand first.
 
 ======================================================================
 Model: Qwen/Qwen3-32B
 ======================================================================
-Based on my analysis of the workflow files:
+Based on my analysis:
 
-**P300X2-supported LLM models:**
+**What it does:** Five standalone agent demos spanning three frameworks
+(smolagents, OpenAI Agents SDK, CrewAI), each demonstrating a different
+agentic pattern against a local vLLM endpoint.
 
-1. **Qwen3-32B** (model_spec.py, lines 1347–1363)
-   - tool_call_parser: `hermes`
-   - reasoning_parser: `qwen3`
-   - Context: 128K tokens
-   - Status: FUNCTIONAL
+**Most important files:**
 
-2. **Llama-3.3-70B-Instruct** (model_spec.py, lines 1837–1863)
-   - tool_call_parser: `llama3_json`
-   - Also aliases: Llama-3.1-70B-Instruct, DeepSeek-R1-Distill-Llama-70B
-   - Context: 128K tokens
-   - Status: FUNCTIONAL
+1. **00_verify_tools.py** — Run this first. Confirms the vLLM server is
+   up, tool calling is working, and structured output parses correctly.
+
+2. **01_research_agent.py** — smolagents CodeAgent. Web search + page
+   reading + synthesis. The simplest demonstration of a real work loop.
+
+3. **04_dungeon_master.py** — The most complex. Shows persistent state
+   via world.json, generative tools (cast_spell, examine_item, manage_lore),
+   and how tool-grounded agents avoid hallucinating world state.
+
+4. **world.json** — The DM's ground truth. Edit this to extend the world.
+
+5. **requirements.txt** — Install order matters; upgrade pip first.
 
 ✓ Code exploration complete
 ```
@@ -489,7 +498,7 @@ python3 ~/code/tt-agents/02_code_explorer.py \
     --query "I'm reviewing a PR that changes authentication. Explain the current auth flow in detail so I can spot regressions."
 ```
 
-**Exploring your QB2's own inference server:**
+**Exploring your QB2's inference server config:**
 ```bash
 python3 ~/code/tt-agents/02_code_explorer.py \
     --dir ~/code/tt-inference-server \

--- a/content/lessons/qb2-local-agents.md
+++ b/content/lessons/qb2-local-agents.md
@@ -683,13 +683,16 @@ python3 ~/code/tt-agents/04_dungeon_master.py --reset
 tt-agents Proof 4: Dungeon Master Agent (smolagents)
 ======================================================================
 Model:    meta-llama/Llama-3.3-70B-Instruct
-State:    ~/code/tt-agents/world.json
+Endpoint: http://localhost:8000/v1
+State:    world.json (fresh)
 
-Tip: 70B gives the best narrative quality. Qwen3-32B is faster (~8s vs ~14s).
-Commands: 'status' = see stats | 'quit' = exit and save
+Tip: 70B gives the best narrative. Qwen3-32B is faster (~8s vs ~14s/turn).
+Commands: 'status' | 'lore' | 'quit'
 ----------------------------------------------------------------------
 
 The DM is setting the scene...
+
+  [get_player_status]
 
 DM: You stand in the Town Square of Millhaven, where the fountain gurgles
     with clear water cold from the mountain springs. Three paths open before
@@ -702,6 +705,10 @@ DM: You stand in the Town Square of Millhaven, where the fountain gurgles
 
 You: Go to the rusty axe
 
+  [get_player_status]
+  [move_player]
+  [manage_lore]
+
 DM: You push through the heavy oak door of the Rusty Axe. Woodsmoke and
     roasted meat. A barkeep polishes mugs with professional disinterest.
     Two farmers argue quietly over a corner table. In the dim light behind
@@ -711,8 +718,10 @@ DM: You push through the heavy oak door of the Rusty Axe. Woodsmoke and
 
 You: Pick up the healing potion
 
-DM: [checking world state...]
-    You reach over the bar with practiced nonchalance. The potion slides
+  [get_player_status]
+  [pick_up_item]
+
+DM: You reach over the bar with practiced nonchalance. The potion slides
     into your pack while the barkeep's attention stays on his mug. It's
     warm from sitting near the hearthfire.
     Inventory: torch, short sword, leather armor, healing_potion.
@@ -720,9 +729,13 @@ DM: [checking world state...]
 You: status
 [Status] HP: 100/100 | Gold: 10 g | Location: The Rusty Axe Tavern
 [Inventory] torch, short sword, leather armor, healing_potion
+[Spells] magic_missile, healing_word, shield  |  Slots: L1:3  L2:2
 [Exits] town_square
 
 You: Ask the barkeep about the dungeon
+
+  [manage_lore]
+  [manage_lore]
 
 DM: The barkeep sets the mug down deliberately and meets your eyes for the
     first time. "People go in," he says. "Most of them even come back out,
@@ -732,6 +745,9 @@ DM: The barkeep sets the mug down deliberately and meets your eyes for the
     names a price that doesn't involve gold.
 
 You: examine the mysterious coin
+
+  [get_player_status]
+  [examine_item]
 
 DM: You turn the coin over in your fingers. The metal is wrong — too light,
     too warm, with a slight give to it that copper shouldn't have. The face
@@ -754,6 +770,8 @@ Farewell, adventurer!
 [Lore entries created this session: 3]
 [Turns played: 5]
 ```
+
+> **Reading the tool lines:** The bracketed names (`[move_player]`, `[manage_lore]`, ...) appear while the DM is thinking — each one is a real JSON tool call made against the world state. They tell you what the agent is doing during the wait without flooding the screen with argument JSON. A turn with `[manage_lore]` twice means the DM invented something new about that NPC and recorded it for future consistency.
 
 ### How It Works
 

--- a/content/lessons/qb2-local-agents.md
+++ b/content/lessons/qb2-local-agents.md
@@ -1,0 +1,1102 @@
+---
+id: qb2-local-agents
+title: Local AI Agents on QuietBox 2
+description: Build real AI agents in pure Python — web research, codebase navigation, multi-agent pipelines, and stateful text adventures — all running locally on your QB2's 32B/70B models
+category: applications
+tags:
+  - qb2
+  - p300x2
+  - agents
+  - smolagents
+  - crewai
+  - openai-agents-sdk
+  - tool-calling
+  - 32b
+  - 70b
+  - local-inference
+supportedHardware:
+  - p300x2
+status: validated
+validatedOn:
+  - p300x2
+estimatedMinutes: 60
+---
+
+# Local AI Agents on QuietBox 2
+
+> **QB2-only lesson.** Everything here requires a 32B or 70B model. The agent reliability gap between 7B and 32B+ is large enough that 7B is not a supported path — the demos will fail or loop indefinitely at smaller scales.
+
+You have a QuietBox 2. You're probably using it to chat with a 70B model and thinking "this is fast." That's true. But that's not the interesting part.
+
+The interesting part is that you now have the hardware to run **AI agents that actually work** — systems that search the web, read files, hand tasks between specialized roles, and maintain state across a full session. These patterns fall apart at 7B. They come together at 32B. They shine at 70B.
+
+This lesson is the raw-Python antidote to the OpenClaw lesson. No frameworks to configure, no services to restart, no JSON files to edit. Five scripts. `pip install`. `python3 run.py`. You see every tool call, every step, every decision the model makes.
+
+---
+
+## What You'll Build
+
+Five standalone demos that grow from simple to sophisticated:
+
+```
+00_verify_tools.py    ── Confirm inference + tool calling work (run this first)
+01_research_agent.py  ── Web search + synthesis via smolagents (60 lines)
+02_code_explorer.py   ── Codebase Q&A via OpenAI Agents SDK (80 lines)
+03_writing_pipeline.py── Researcher → Writer → Editor via CrewAI (100 lines)
+04_dungeon_master.py  ── Stateful interactive agent via smolagents (120 lines)
+```
+
+Each demo uses a different framework to show you the landscape. By the end you'll know which framework to reach for and why, and you'll have a foundation to build real things on top of.
+
+---
+
+## Why 32B Changes Everything for Agents
+
+A language model doing a single task — answer this question, translate this text — is forgiving. A model operating as an **agent** is not. Agents must:
+
+1. Decide *which tool* to call from a list of options
+2. Format *valid JSON* arguments for that tool
+3. Interpret the tool's return value
+4. Decide *whether to call another tool* or respond
+5. Maintain coherent intent across multiple steps
+
+Each decision is a place to fail. The math compounds:
+
+| Task | 7B success rate | 32B success rate | 70B success rate |
+|------|----------------|-----------------|-----------------|
+| Single tool call | ~78% | ~93% | ~96% |
+| 3-step ReAct loop | ~52% | ~78% | ~88% |
+| Multi-agent pipeline | ~30% | ~70% | ~82% |
+
+A 3-step loop with 7B succeeds barely half the time. The same loop with 32B works 3 out of 4 times. Your QB2 runs Qwen3-32B at ~8 seconds per response and Llama-3.3-70B-Instruct at ~14 seconds. Both are genuinely usable. Neither requires a cloud subscription or an NVIDIA GPU.
+
+---
+
+## Performance at a Glance
+
+| What | Time | Model |
+|------|------|-------|
+| Single tool call | ~8–14 s | Qwen3-32B / Llama-3.3-70B |
+| Research agent (5 steps) | ~3–5 min | Qwen3-32B |
+| Code explorer (3 hops) | ~1–2 min | Qwen3-32B or Llama-3.3-70B |
+| Writing pipeline (3 agents) | ~5–15 min | Qwen3-32B |
+| DM response (per turn) | ~10–16 s | Llama-3.3-70B (recommended) |
+
+---
+
+## Prerequisites
+
+- QB2 hardware healthy: `tt-smi -s` shows 4 chips
+- `~/code/tt-inference-server` cloned and working
+- Docker running
+- Internet access (for the web-search demo and model downloads)
+
+**Verify your QB2:**
+
+```bash
+tt-smi -s | python3 -c "import json,sys; d=json.load(sys.stdin); print(f'{len(d[\"device_info\"])} chips detected')"
+# Should print: 4 chips detected
+```
+
+[Run Hardware Detection](command:tenstorrent.runHardwareDetection)
+
+---
+
+## Step 1: Start the Inference Server
+
+The demos need a vLLM endpoint running on port 8000. Use **Qwen3-32B** for the fastest iteration, or **Llama-3.3-70B-Instruct** for maximum output quality — especially for the Dungeon Master demo.
+
+### Option A — Qwen3-32B (~8 s/response, recommended for most demos)
+
+```bash
+cd ~/code/tt-inference-server
+
+python3 run.py \
+    --model Qwen3-32B \
+    --tt-device p300x2 \
+    --workflow server \
+    --docker-server \
+    --no-auth \
+    --vllm-override-args '{"enable_auto_tool_choice": true, "tool_call_parser": "hermes"}'
+```
+
+[Start Qwen3-32B Server](command:tenstorrent.startQb2AgentsServerQwen)
+
+### Option B — Llama-3.3-70B-Instruct (~14 s/response, best for Dungeon Master)
+
+```bash
+cd ~/code/tt-inference-server
+
+python3 run.py \
+    --model Llama-3.3-70B-Instruct \
+    --tt-device p300x2 \
+    --workflow server \
+    --docker-server \
+    --no-auth \
+    --vllm-override-args '{"enable_auto_tool_choice": true, "tool_call_parser": "llama3_json"}'
+```
+
+[Start Llama-3.3-70B Server](command:tenstorrent.startQb2AgentsServerLlama)
+
+> **`--enable_auto_tool_choice` is not optional.** Without it, the model will respond in prose instead of making tool calls. The `tool_call_parser` must match the model — `hermes` for Qwen, `llama3_json` for Llama.
+
+**Wait for warmup** (5 minutes on a warm cache, up to 20 minutes if downloading for the first time). The server is ready when:
+
+```bash
+curl http://localhost:8000/v1/models
+# → {"data":[{"id":"Qwen/Qwen3-32B",...}]}
+```
+
+[Check Server Health](command:tenstorrent.checkAgentServerHealth)
+
+---
+
+## Step 2: Get the Agent Scripts
+
+Clone the demo repository and install Python dependencies:
+
+```bash
+# Clone the demos (if not already present)
+git clone https://github.com/tenstorrent/tt-agents.git ~/code/tt-agents
+cd ~/code/tt-agents
+
+# Upgrade pip first — some crewai sub-dependencies require it
+pip install --upgrade pip setuptools wheel
+
+# Install all framework dependencies
+pip install -r requirements.txt
+```
+
+[Clone tt-agents](command:tenstorrent.cloneTtAgents)
+
+**What gets installed:**
+
+```
+smolagents     — HuggingFace's lightweight agent framework (CodeAgent + ToolCallingAgent)
+openai-agents  — OpenAI Agents SDK (@function_tool decorator, async Runner)
+crewai         — Role-based multi-agent orchestration
+ddgs           — DuckDuckGo search (smolagents 1.13+ requires ddgs, not duckduckgo-search)
+beautifulsoup4 — Web page parsing
+markdownify    — HTML-to-markdown converter (required by smolagents' visit_webpage tool)
+openai         — OpenAI-compatible client (works against local vLLM)
+```
+
+**Copy to tt-scratchpad** so you can modify freely without touching the originals:
+
+```bash
+mkdir -p ~/tt-scratchpad/agents
+cp ~/code/tt-agents/*.py ~/tt-scratchpad/agents/
+cp ~/code/tt-agents/requirements.txt ~/tt-scratchpad/agents/
+cp ~/code/tt-agents/world.json ~/tt-scratchpad/agents/
+```
+
+[Copy Scripts to Scratchpad](command:tenstorrent.copyAgentsToScratchpad)
+
+> Scripts in `~/tt-scratchpad/agents/` are yours to hack. The originals in `~/code/tt-agents/` stay clean.
+
+---
+
+## Step 3: Verify Everything Works
+
+Before running any demos, confirm inference and tool calling are both functioning:
+
+```bash
+python3 ~/code/tt-agents/00_verify_tools.py
+```
+
+[Run Tool Verification](command:tenstorrent.runAgentsVerify)
+
+**Expected output:**
+
+```
+============================================================
+tt-agents: Tool Calling Verification
+============================================================
+
+Endpoint: http://localhost:8000/v1
+  Found model: Qwen/Qwen3-32B
+
+[1/3] Basic inference...
+  ✓ Response: INFERENCE_OK
+
+[2/3] Tool call (function calling)...
+  ✓ Tool called: get_weather({'city': 'San Francisco'})
+
+[3/3] Structured output (JSON mode)...
+  ✓ Parsed JSON: {'status': 'ok', 'count': 42}
+
+============================================================
+  ✓ inference
+  ✓ tool_call
+  ✓ structured
+
+✅ All checks passed. Ready to run agent demos!
+```
+
+**If tool_call fails:** The most common cause is a mismatch between the model and the parser flag. Check that you used `--tool-call-parser hermes` with Qwen3-32B, or `--tool-call-parser llama3_json` with Llama-3.3-70B-Instruct.
+
+---
+
+## Demo 1: Research Agent
+
+**Framework:** smolagents `CodeAgent` | **~60 lines** | **Model:** Qwen3-32B
+
+An agent that searches the web, reads pages, and synthesizes a cited report. This is the demo that makes people say "oh, *this* is what a local LLM is actually for."
+
+```bash
+python3 ~/code/tt-agents/01_research_agent.py
+```
+
+[Run Research Agent](command:tenstorrent.runResearchAgent)
+
+The script opens a **topic picker** — eight research prompts across tech, travel, philosophy, gaming, and more. Pick a number, paste your own query, or just press Enter to accept today's highlighted suggestion. It auto-continues after 10 seconds if you walk away.
+
+```
+Research topic — pick a number, paste your own query, or press Enter:
+
+    [1] Python AI agent libraries
+    [2] East Coast music festivals 2026
+    [3] Walter Benjamin on AI video and the prompt artist
+    [4] Attracting beneficial insects to any garden
+    [5] Roguelike vs roguelite — genre lineage 1980–2026
+    [6] Best blog platforms for GitHub Pages in 2026
+    [7] Invent an original word puzzle mechanic
+  → [8] Underrated US national parks and public lands
+
+  Auto-continuing with [8] in 10s...
+>
+```
+
+The highlighted suggestion (`→`) rotates daily, so every time you run it you see a different default.
+
+**Run without any prompt (useful in scripts or scheduled jobs):**
+
+```bash
+python3 ~/code/tt-agents/01_research_agent.py --headless
+```
+
+**Pass your own query directly:**
+
+```bash
+python3 ~/code/tt-agents/01_research_agent.py \
+    --query "What are the most-cited safety concerns with agentic AI systems in 2025-2026? Summarize 3 key papers or posts with links."
+```
+
+**Sample output:**
+
+```
+======================================================================
+tt-agents Proof 1: Research Agent (smolagents)
+======================================================================
+Model:    Qwen/Qwen3-32B
+Endpoint: http://localhost:8000/v1
+
+Query:
+  Research the current state of open-source AI inference hardware...
+----------------------------------------------------------------------
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 1 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ─ Executing this code:
+results = web_search(query="open source AI inference hardware 2025 alternatives NVIDIA")
+print(results)
+ ─ Execution logs:
+[search results...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 2 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ─ Executing this code:
+page = visit_webpage(url="https://tenstorrent.com/hardware/quietbox")
+print(page[:3000])
+ ─ Execution logs:
+[page content...]
+
+...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Step 5 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ─ Executing this code:
+final_answer("Open-source AI inference hardware has matured significantly...")
+
+======================================================================
+FINAL RESULT:
+======================================================================
+Open-source AI inference hardware has matured significantly heading into 2026.
+Three companies have moved beyond vaporware into shipping products:
+
+**Tenstorrent (QuietBox 2 / Blackhole):** The QB2 runs Qwen3-32B at ~8 s/response
+and Llama-3.3-70B-Instruct at ~14 s/response on 4× Blackhole ASICs...
+
+✓ Completed in 5 steps
+```
+
+> **Qwen3 extended thinking:** Qwen3-32B uses chain-of-thought reasoning internally. You may see `<think>...</think>` blocks appear in step output before the actual tool call — this is the model working through its reasoning and is normal. The final answer does not include these tags.
+
+
+### How It Works
+
+The `CodeAgent` is smolagents' most powerful mode. Instead of emitting JSON tool call objects, it **writes Python code** to call tools:
+
+```python
+# What the model generates internally:
+results = web_search("open source AI inference hardware 2025")
+page = visit_webpage(results[0]['url'])
+# ... then synthesizes all gathered info into a final answer
+```
+
+This is why it's robust even with imperfect tool calling config — the model is writing code, not formatting JSON. It handles multi-hop research loops naturally.
+
+### Real-World Uses
+
+**Before committing to a library:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py \
+    --query "Research known security vulnerabilities and CVEs in the 'requests' Python library versions 2.28-2.32. What versions are safe?"
+```
+
+**Before a technical meeting:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py \
+    --query "Summarize the last 3 months of activity on the vLLM GitHub repo. What major features shipped? What are the open blockers?"
+```
+
+**Competitive intelligence:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py \
+    --query "Compare Anthropic Claude API, OpenAI API, and local Llama pricing for a workload of 10M tokens/day. Include current pricing from their websites."
+```
+
+**Understanding a new topic before diving in:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py \
+    --query "I'm new to Kubernetes. What are the top 5 concepts I need to understand first, and what's a common mistake beginners make with each?"
+```
+
+---
+
+## Demo 2: Codebase Explorer
+
+**Framework:** OpenAI Agents SDK | **~80 lines** | **Model:** Qwen3-32B or Llama-3.3-70B
+
+Point this at any directory and ask questions. This is what a local coding assistant looks like at the architectural level — it actually reads your files.
+
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/tt-inference-server/workflows
+```
+
+[Run Code Explorer](command:tenstorrent.runCodeExplorer)
+
+**Explore your own code:**
+
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/YOUR_PROJECT \
+    --query "How does authentication work in this codebase? Walk me through the request flow."
+```
+
+**Compare 32B vs 70B output quality side by side:**
+
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/tt-inference-server/workflows \
+    --compare
+```
+
+**Sample output:**
+
+```
+======================================================================
+tt-agents Proof 2: Codebase Explorer (OpenAI Agents SDK)
+======================================================================
+Endpoint: http://localhost:8000/v1
+Directory: /home/ttuser/code/tt-inference-server/workflows
+
+Query:
+  Which LLM models support P300X2 and what tool parsers do they use?
+
+======================================================================
+Model: Qwen/Qwen3-32B
+======================================================================
+Based on my analysis of the workflow files:
+
+**P300X2-supported LLM models:**
+
+1. **Qwen3-32B** (model_spec.py, lines 1347–1363)
+   - tool_call_parser: `hermes`
+   - reasoning_parser: `qwen3`
+   - Context: 128K tokens
+   - Status: FUNCTIONAL
+
+2. **Llama-3.3-70B-Instruct** (model_spec.py, lines 1837–1863)
+   - tool_call_parser: `llama3_json`
+   - Also aliases: Llama-3.1-70B-Instruct, DeepSeek-R1-Distill-Llama-70B
+   - Context: 128K tokens
+   - Status: FUNCTIONAL
+
+✓ Code exploration complete
+```
+
+### How It Works
+
+The agent uses three tools with explicit JSON schemas via the `@function_tool` decorator:
+
+```python
+@function_tool
+def read_file(path: str) -> str:
+    """Read a text file from disk (truncated at 32KB)."""
+    ...
+
+@function_tool
+def list_files(directory: str, pattern: str = "*") -> str:
+    """List files matching a glob pattern."""
+    ...
+
+@function_tool
+def grep_code(pattern: str, directory: str, file_extension: str = ".py") -> str:
+    """Search for a regex pattern, returning file:line matches."""
+    ...
+```
+
+Every tool call is a real JSON function call object — you can see exactly what the model decided to read and why. This is the right pattern for production tools where auditability matters.
+
+> **Qwen3 extended thinking:** With Qwen3-32B you may see `<think>...</think>` blocks in the raw output between tool calls — the model working through its reasoning before committing to a file read or search. The final answer is clean. If you prefer to suppress it, add `extra_body={"chat_template_kwargs": {"enable_thinking": False}}` when constructing the OpenAI client.
+
+### Real-World Uses
+
+**Day 1 at a new job:**
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/company-app/src \
+    --query "Give me a tour of this codebase. What does it do, how is it organized, and what are the most important files to understand first?"
+```
+
+**Security audit:**
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/my-api \
+    --query "Find all places where user-provided input is passed to SQL queries, shell commands, or eval(). List file:line for each."
+```
+
+**Documentation generation:**
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/my-library \
+    --query "List every public function and class with its parameters and a one-sentence description of what it does."
+```
+
+**Understanding a PR before reviewing:**
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/project \
+    --query "I'm reviewing a PR that changes authentication. Explain the current auth flow in detail so I can spot regressions."
+```
+
+**Exploring your QB2's own inference server:**
+```bash
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir ~/code/tt-inference-server \
+    --query "How does run.py decide which Docker image to use? Trace the logic from command-line flags to the final image selection."
+```
+
+---
+
+## Demo 3: Multi-Agent Writing Pipeline
+
+**Framework:** CrewAI | **~100 lines** | **Model:** Qwen3-32B
+
+Three specialized agents collaborate sequentially: a **Researcher** builds a factual outline, a **Writer** drafts from it, an **Editor** polishes the result. The output is measurably better than any single agent produces.
+
+**This demo chains with Demo 1.** If you ran the Research Agent first, its output is loaded automatically and the Researcher agent is skipped — the pipeline goes straight to Writer → Editor with real research already in hand. Run them back to back and watch the full chain:
+
+```bash
+python3 ~/code/tt-agents/01_research_agent.py   # saves last_research.txt
+python3 ~/code/tt-agents/03_writing_pipeline.py  # picks it up automatically
+```
+
+[Run Writing Pipeline](command:tenstorrent.runWritingPipeline)
+
+The pipeline opens a **format picker** — choose how the piece is written, not just what it covers:
+
+```
+Writing format — pick a number, paste your own instruction, or press Enter:
+
+    [1] Developer blog post
+    [2] Tweet thread (≤140 chars each)
+  → [3] Explain it like I'm curious but new
+    [4] Devil's advocate — argue the opposite
+    [5] Lyrical / prose poetry
+    [6] Executive one-pager
+    [7] Reddit thread — multiple POVs
+
+  Auto-continuing with [3] in 10s...
+>
+```
+
+The same research can become a tweet thread, an executive briefing, a Reddit discussion, or prose poetry — just run it again and pick a different format.
+
+**Run without prompts:**
+
+```bash
+python3 ~/code/tt-agents/03_writing_pipeline.py --headless
+```
+
+**Force a fresh research run (ignore saved research):**
+
+```bash
+python3 ~/code/tt-agents/03_writing_pipeline.py --no-research \
+    --topic "How Tenstorrent's Blackhole architecture differs from GPU inference"
+```
+
+**Expected timeline:**
+
+```
+With pre-loaded research (Writer → Editor only):
+  [Writer]  Drafting in chosen format...  (~2–5 min)
+  [Editor]  Polishing...                  (~1–3 min)
+  Total:    ~3–8 minutes
+
+Without pre-loaded research (Researcher → Writer → Editor):
+  [Researcher] Building factual outline... (~1–3 min)
+  [Writer]     Drafting...                 (~2–5 min)
+  [Editor]     Polishing...                (~1–3 min)
+  Total:       ~5–15 minutes
+```
+
+> Each agent makes multiple LLM calls at ~8 s each — grab a coffee either way.
+
+**Sample output (excerpt):**
+
+```
+======================================================================
+FINAL ARTICLE:
+======================================================================
+
+# Why 32B Models Finally Make Local AI Agents Viable
+
+Seven billion parameters sounds like a lot until you ask your model to search
+the web, read a file, and synthesize an answer — in that order. At 7B, that
+loop fails about half the time. At 32B, it works three times out of four.
+That's not a marginal improvement. That's the difference between a toy and a tool.
+
+The bottleneck isn't intelligence — it's reliability. Agents must format valid
+JSON for every tool call, interpret the response, and decide what to do next.
+Each step is an opportunity to hallucinate an argument, call the wrong tool, or
+lose track of the goal. Smaller models accumulate these errors; larger ones
+mostly don't.
+
+Tenstorrent's QuietBox 2 runs Qwen3-32B at roughly eight seconds per response
+on four Blackhole ASICs...
+
+✓ Pipeline complete
+```
+
+### How It Works
+
+Each agent has a narrowly scoped **role**, **goal**, and **backstory**. When research is pre-loaded from Demo 1, the Researcher is skipped entirely and its output is fed directly into the Writer's task. Role separation is what makes this better than one big prompt — and the format instruction travels with the research so every agent knows the target form.
+
+```python
+# With pre-loaded research — 2 agents
+writing_task = Task(
+    description=(
+        "FORMAT INSTRUCTION — follow this exactly:\n"
+        "Write a thread of 10-14 tweets. EVERY tweet must be ≤140 characters...\n\n"
+        "RESEARCH:\n<output from 01_research_agent.py>"
+    ),
+    agent=writer,
+)
+
+# Without — 3 agents, Researcher runs first
+research_task = Task(description="Research the topic...", agent=researcher)
+writing_task = Task(context=[research_task], ...)
+editing_task = Task(context=[writing_task], ...)
+```
+
+### Real-World Uses
+
+The format picker changes everything here. The same facts become different artifacts:
+
+**Research once, publish everywhere:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py --query "What's new in Rust 2025?"
+python3 ~/code/tt-agents/03_writing_pipeline.py        # → tweet thread
+python3 ~/code/tt-agents/03_writing_pipeline.py        # → exec one-pager
+python3 ~/code/tt-agents/03_writing_pipeline.py        # → ELI5 for onboarding docs
+```
+
+**Postmortem in every format your team needs:**
+```bash
+python3 ~/code/tt-agents/03_writing_pipeline.py --no-research \
+    --topic "Database outage: 45 minutes, connection pool misconfiguration, 14:23–15:08, no data loss"
+# Pick [6] Executive one-pager for your VP
+# Pick [7] Reddit thread to share the learning publicly
+# Pick [1] Blog post for the engineering blog
+```
+
+**Turn research agent output into a tweet thread:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py  # research any topic
+python3 ~/code/tt-agents/03_writing_pipeline.py # pick [2] Tweet thread
+```
+
+**Make any topic approachable:**
+```bash
+python3 ~/code/tt-agents/01_research_agent.py --query "How does RDMA networking work?"
+python3 ~/code/tt-agents/03_writing_pipeline.py  # pick [3] ELI5
+```
+
+---
+
+## Demo 4: Dungeon Master Agent
+
+**Framework:** smolagents `ToolCallingAgent` | **~120 lines** | **Model:** Llama-3.3-70B (recommended)
+
+An interactive text adventure where the DM is your local LLM — with tools to enforce world state consistency, large context to remember your full session, and enough reasoning depth to make narrative decisions feel genuine. This is the demo that shows what stateful agents look like.
+
+```bash
+# Recommended: 70B for narrative quality
+python3 ~/code/tt-agents/04_dungeon_master.py
+
+# Faster (still fun, ~8 s/turn) — use this if you started Qwen3-32B in Step 1
+python3 ~/code/tt-agents/04_dungeon_master.py --model "Qwen/Qwen3-32B"
+
+# Start fresh (clear session state)
+python3 ~/code/tt-agents/04_dungeon_master.py --reset
+```
+
+> If you started Qwen3-32B (Option A) in Step 1, pass `--model "Qwen/Qwen3-32B"` to all DM commands. The default assumes Llama-3.3-70B-Instruct is loaded. Both work well — 70B has richer narrative prose, 32B responds in ~8 s.
+
+[Start Dungeon Master](command:tenstorrent.runDungeonMaster)
+
+> **State persists between sessions** in `world_session.json`. Quit and come back — the DM remembers where you were.
+
+**Full sample session:**
+
+```
+======================================================================
+tt-agents Proof 4: Dungeon Master Agent (smolagents)
+======================================================================
+Model:    meta-llama/Llama-3.3-70B-Instruct
+State:    ~/code/tt-agents/world.json
+
+Tip: 70B gives the best narrative quality. Qwen3-32B is faster (~8s vs ~14s).
+Commands: 'status' = see stats | 'quit' = exit and save
+----------------------------------------------------------------------
+
+The DM is setting the scene...
+
+DM: You stand in the Town Square of Millhaven, where the fountain gurgles
+    with clear water cold from the mountain springs. Three paths open before
+    you: north toward the Dark Forest where the treeline begins to thicken
+    and the shadows pool early; east to the Rusty Axe Tavern, its sign
+    swinging in the afternoon breeze; and south toward the dungeon entrance,
+    which the locals avoid discussing over dinner. Your leather armor sits
+    comfortably across your shoulders. Your short sword is at your hip.
+    You have 10 gold coins and a torch.
+
+You: Go to the rusty axe
+
+DM: You push through the heavy oak door of the Rusty Axe. Woodsmoke and
+    roasted meat. A barkeep polishes mugs with professional disinterest.
+    Two farmers argue quietly over a corner table. In the dim light behind
+    the bar, half-hidden by a coil of rope, you notice something glinting
+    on the shelf — a healing potion, apparently forgotten or deliberately
+    hidden. The barkeep hasn't looked up yet.
+
+You: Pick up the healing potion
+
+DM: [checking world state...]
+    You reach over the bar with practiced nonchalance. The potion slides
+    into your pack while the barkeep's attention stays on his mug. It's
+    warm from sitting near the hearthfire.
+    Inventory: torch, short sword, leather armor, healing_potion.
+
+You: status
+[Status] HP: 100/100 | Gold: 10 g | Location: The Rusty Axe Tavern
+[Inventory] torch, short sword, leather armor, healing_potion
+[Exits] town_square
+
+You: Ask the barkeep about the dungeon
+
+DM: The barkeep sets the mug down deliberately and meets your eyes for the
+    first time. "People go in," he says. "Most of them even come back out,
+    the first time." He goes back to polishing. A long pause. "The key to
+    level one — rusty thing, opens a chest nobody's found yet — it's yours
+    if you bring me proof someone cleared the skeleton on level two." He
+    names a price that doesn't involve gold.
+
+You: examine the mysterious coin
+
+DM: You turn the coin over in your fingers. The metal is wrong — too light,
+    too warm, with a slight give to it that copper shouldn't have. The face
+    shows a figure you don't recognize. You flip it to the date side and
+    read it twice before it registers: forty years from now.
+
+You: lore
+[World Lore — recorded by the DM this session]
+  barkeep: Former adventurer named Oswin. Lost two fingers to a pressure
+    plate on Level 3. Retired the day his partner didn't come back. Knows
+    more about the dungeon than he admits.
+  mysterious_coin: Origin unknown. The date suggests either a forgery, a
+    time anomaly, or something the archivist would recognize immediately.
+  crypt runes: Pre-date the town by at least three centuries. The archivist
+    has a partial translation she won't share.
+
+You: quit
+Farewell, adventurer!
+[World state saved to world_session.json]
+[Lore entries created this session: 3]
+[Turns played: 5]
+```
+
+### How It Works
+
+The script ships with **ten tools** in two categories. The first five enforce world state — the DM physically cannot invent an exit, teleport the player, or ignore HP. The second five are *generative* — the model calls them to create new material and have it persist.
+
+**State enforcement tools** (the DM cannot cheat):
+```python
+@tool
+def move_player(destination: str) -> str:
+    """Move the player — only succeeds if destination is a valid exit."""
+
+@tool
+def pick_up_item(item_name: str) -> str:
+    """Pick up an item — only if it's actually in the current location."""
+
+@tool
+def update_player_hp(change: int, reason: str) -> str:
+    """Modify HP — negative = damage, positive = healing."""
+```
+
+**Generative tools** (the DM creates real, persistent material):
+```python
+@tool
+def cast_spell(spell_name: str, target: str) -> str:
+    """Cast a spell from the player's spellbook. Consumes a slot. Returns the mechanical
+    effect — the DM narrates it. Slots are tracked and saved."""
+
+@tool
+def examine_item(item_name: str) -> str:
+    """Examine an item closely. Returns its surface description AND hidden properties —
+    the mysterious coin's date is forty years in the future; the short sword's maker's mark
+    matches one in the torn journal. None of this is in the narrative until the player looks."""
+
+@tool
+def manage_lore(subject: str, description: str = "") -> str:
+    """Record or retrieve lore about any person, place, or object.
+    When the DM invents the barkeep's backstory or the crypt's history, it calls this
+    to save the canon. On later turns it retrieves it — so the barkeep stays consistent
+    across every session, not just within one conversation."""
+
+@tool
+def check_rules(action: str) -> str:
+    """Validate whether an action is possible given current state — spell slots, weapons
+    present, available exits. Call before resolving anything unusual."""
+```
+
+**Adding a new tool takes about 10 lines.** Name it, write a docstring the model will read, touch world state, add it to the tools list. The model figures out the rest:
+
+```python
+# Want a crafting tool? This is all you need:
+@tool
+def craft_item(ingredient_a: str, ingredient_b: str) -> str:
+    """Combine two items from inventory to attempt crafting something new.
+    Only works if both items are in the player's inventory.
+
+    Args:
+        ingredient_a: First item name.
+        ingredient_b: Second item name.
+    """
+    inv = _world_state["player"]["inventory"]
+    if ingredient_a not in inv or ingredient_b not in inv:
+        return f"Need both items in inventory. Have: {inv}"
+    # Remove ingredients, add result, save — the DM narrates the outcome
+    inv.remove(ingredient_a)
+    inv.remove(ingredient_b)
+    result = f"{ingredient_a}+{ingredient_b} creation"
+    inv.append(result)
+    save_world(_world_state)
+    return f"Combined {ingredient_a} and {ingredient_b} → {result}"
+```
+
+The world itself reflects this depth. The crypt has a spirit NPC and items with dark history. Every item in `item_details` has a surface description and a `hidden` property that only surfaces when `examine_item` is called — a coin with a future date, a sword whose maker's mark connects to the dungeon's history, a journal whose last line reads: *"The crypt is not a dead end. It is a door."* The model builds on all of this through tool calls, not hallucination.
+
+**The `lore` command** (type it at the prompt) shows you everything the DM has recorded during the session — every NPC's backstory, every invented fact, every secret it decided to commit to. By the end of a real session, it's a living document the model wrote itself.
+
+### The Pattern Behind the Game
+
+The Dungeon Master is a toy, but the architecture is real. Here's what it actually demonstrates:
+
+**Pattern: Tool-grounded stateful agent.** The LLM is a reasoning and language layer. Actual state lives in structured storage (JSON, a database, an API). The model reads state via tools before acting, and writes state via tools after acting. It cannot hallucinate state it doesn't have access to.
+
+This is exactly how you'd build:
+
+**A personal task assistant:**
+```
+Tools: list_tasks(), add_task(), mark_complete(), get_priorities()
+State: tasks.json / SQLite
+Prompt: "What should I focus on this afternoon?"
+```
+
+**A customer service agent:**
+```
+Tools: get_order_status(), lookup_account(), create_ticket(), update_ticket()
+State: your CRM / order management system
+Prompt: customer message → agent handles → state updated
+```
+
+**A PR review assistant with memory:**
+```
+Tools: read_file(), get_diff(), add_comment(), list_open_issues()
+State: GitHub API (via tools)
+Prompt: "Review this PR for security issues, remembering we're migrating to OAuth"
+```
+
+The Dungeon Master is the smallest possible version of all of these. Once you understand it, the others are just different tools and different state.
+
+---
+
+## Modify the Scripts
+
+The scripts in `~/tt-scratchpad/agents/` are your starting point for building real things.
+
+**Change the research agent's default query:**
+
+```bash
+# Edit ~/tt-scratchpad/agents/01_research_agent.py
+# Line 33: DEFAULT_QUERY = "..."
+# Set it to something you actually want to research every morning
+```
+
+**Add a new tool to the code explorer:**
+
+```python
+# ~/tt-scratchpad/agents/02_code_explorer.py
+
+@function_tool
+def summarize_function(file_path: str, function_name: str) -> str:
+    """Read a specific function from a file and return just that function's code."""
+    # Find the function, extract it, return it
+    ...
+```
+
+**Give the writing pipeline a fourth agent:**
+
+```python
+# ~/tt-scratchpad/agents/03_writing_pipeline.py
+fact_checker = Agent(
+    role="Fact Checker",
+    goal="Verify every specific claim against what you know is accurate",
+    backstory="You flag anything that sounds made-up or imprecise...",
+    llm=llm,
+)
+```
+
+**Extend the dungeon master's world:**
+
+```bash
+# ~/tt-scratchpad/agents/world.json
+# Add new locations to "locations" dict
+# Add new enemies to "enemies" dict
+# Add items to location "items" lists
+# The DM automatically uses whatever's in the JSON
+```
+
+---
+
+## Build Your Own Agent
+
+Every agent in this lesson follows the same three-step pattern:
+
+```python
+from smolagents import OpenAIServerModel, ToolCallingAgent, tool
+import openai
+
+# 1. Define tools
+@tool
+def my_tool(arg: str) -> str:
+    """What this tool does — the model reads this docstring."""
+    return do_real_work(arg)
+
+# 2. Connect to your QB2's inference endpoint
+model = OpenAIServerModel(
+    model_id="Qwen/Qwen3-32B",
+    api_base="http://localhost:8000/v1",
+    api_key="none",
+)
+
+# 3. Build and run the agent
+agent = ToolCallingAgent(tools=[my_tool], model=model, max_steps=10)
+result = agent.run("Do something useful with my_tool")
+print(result)
+```
+
+**Minimal research agent (15 lines):**
+
+```python
+from smolagents import CodeAgent, DuckDuckGoSearchTool, OpenAIServerModel
+
+model = OpenAIServerModel(model_id="Qwen/Qwen3-32B", api_base="http://localhost:8000/v1", api_key="none")
+agent = CodeAgent(tools=[DuckDuckGoSearchTool()], model=model, max_steps=5)
+print(agent.run("What is the current state of the art in protein folding prediction?"))
+```
+
+**Minimal file agent (20 lines):**
+
+```python
+import asyncio, os, openai
+from agents import Agent, Runner, function_tool, OpenAIChatCompletionsModel
+
+@function_tool
+def read_file(path: str) -> str:
+    """Read a file from disk."""
+    return open(os.path.expanduser(path)).read()
+
+# OpenAI Agents SDK parses the model string for a provider prefix — use
+# OpenAIChatCompletionsModel to route directly to your local vLLM endpoint.
+client = openai.AsyncOpenAI(base_url="http://localhost:8000/v1", api_key="none")
+model = OpenAIChatCompletionsModel(model="Qwen/Qwen3-32B", openai_client=client)
+
+agent = Agent(name="FileReader", instructions="Answer questions about files.", tools=[read_file], model=model)
+print(asyncio.run(Runner.run(agent, "Summarize ~/code/tt-agents/README.md")).final_output)
+```
+
+---
+
+## Framework Cheat Sheet
+
+| Framework | When to use | Why |
+|-----------|-------------|-----|
+| **smolagents CodeAgent** | Research, multi-hop tasks | Writes Python code to call tools — robust even with imperfect tool calling config |
+| **smolagents ToolCallingAgent** | Stateful/interactive agents | JSON tool calls — more auditable, better for interactive sessions |
+| **OpenAI Agents SDK** | Production tools, async | Explicit JSON schemas via `@function_tool`, async-first, close to the metal |
+| **CrewAI** | Multi-role pipelines | Role-based orchestration — the cleanest pattern for Researcher → Writer → Editor flows |
+
+**Which model?**
+
+- Qwen3-32B: 8 s/response, reliable tool calling, `hermes` parser — use for everything except narrative tasks
+- Llama-3.3-70B: 14 s/response, better reasoning depth, `llama3_json` parser — use when output quality matters more than speed (writing pipeline, dungeon master, complex code review)
+
+---
+
+## Troubleshooting
+
+### Tool calls always fail / model responds in prose
+
+**Cause:** Missing or wrong vLLM flags.
+
+```bash
+# Verify the flags are active
+curl -s http://localhost:8000/v1/models | python3 -m json.tool
+# If the server started correctly you'll see the model ID
+
+# Re-run verify script to confirm tool calling works
+python3 ~/code/tt-agents/00_verify_tools.py
+# If [2/3] fails: restart with correct --tool-call-parser for your model
+```
+
+### Research agent loops indefinitely or gives up after 2 steps
+
+**Cause:** 7B-class reasoning behavior at tool call boundaries (but you're on QB2 with 32B — check model actually loaded).
+
+```bash
+# Confirm which model is actually running
+curl http://localhost:8000/v1/models
+# Should show Qwen/Qwen3-32B or meta-llama/Llama-3.3-70B-Instruct
+# If something smaller loaded, restart the server
+```
+
+### Code explorer returns "Directory not found"
+
+**Cause:** Path expansion issue with `~`.
+
+```bash
+# Always expand ~ before passing to the script
+python3 ~/code/tt-agents/02_code_explorer.py \
+    --dir /home/ttuser/code/my-project \
+    --query "..."
+```
+
+### Writing pipeline hangs between agents
+
+**Cause:** CrewAI's inter-agent context can sometimes exceed the model's working window.
+
+```bash
+# Reduce topic complexity or explicitly scope the output
+python3 ~/code/tt-agents/03_writing_pipeline.py \
+    --topic "Write 400 words about X. Be concise."
+```
+
+### Dungeon master ignores what I did last session
+
+**Cause:** Session state not loading correctly. Check file exists:
+
+```bash
+ls -la ~/code/tt-agents/world_session.json
+# Should exist after any previous run
+# If corrupted, reset to fresh state:
+python3 ~/code/tt-agents/04_dungeon_master.py --reset
+```
+
+### `pip install -r requirements.txt` fails on crewai
+
+```bash
+# Upgrade pip first
+pip install --upgrade pip setuptools wheel
+pip install -r requirements.txt
+```
+
+### Research agent fails with `ImportError: No module named 'ddgs'`
+
+smolagents 1.13+ requires the `ddgs` package, not the older `duckduckgo-search`:
+
+```bash
+pip uninstall duckduckgo-search -y
+pip install ddgs
+```
+
+If you cloned an older version of tt-agents or built your own requirements.txt, make sure it lists `ddgs>=9.0.0` (not `duckduckgo-search`).
+
+---
+
+## What You've Built
+
+You've run four different agentic patterns against your QB2's local inference endpoint:
+
+- ✅ **Research synthesis** — multi-hop web search with cited output (smolagents CodeAgent)
+- ✅ **Codebase Q&A** — file navigation and code comprehension (OpenAI Agents SDK)
+- ✅ **Multi-role pipeline** — specialized agents handing off to each other (CrewAI)
+- ✅ **Stateful interactivity** — tool-grounded persistent world state (smolagents ToolCallingAgent)
+
+More importantly, you've seen the three things that make these patterns work:
+
+1. **32B+ models** that reliably format tool calls and follow multi-step instructions
+2. **Large context** — vLLM defaults to 32K tokens in this config, which is enough for multi-turn sessions and full research loops; bump `max_model_len` in the server config for longer sessions
+3. **Local inference** that lets you iterate without API bills, rate limits, or data leaving your machine
+
+The scripts are short on purpose. Each one is a skeleton you can grow. The code explorer becomes your codebase assistant. The writing pipeline becomes your documentation tool. The dungeon master becomes your customer service bot or personal task tracker. The research agent becomes the thing that briefs you before every meeting.
+
+---
+
+## What's Next
+
+**See how OpenClaw packages these patterns into a production service:**
+
+[OpenClaw AI Assistant on QuietBox 2](command:tenstorrent.showLesson?["qb2-openclaw-assistant"])
+
+OpenClaw is what you'd build if you took the dungeon master pattern seriously: persistent memory, multi-agent routing, a WebSocket API, and a terminal UI. Now that you've seen the raw version, the architecture makes more sense.
+
+**Generate video on your QB2:**
+
+[Generating Video on QuietBox 2](command:tenstorrent.showLesson?["qb2-video-generation"])
+
+**Explore the framework comparison** (included in the tt-agents repo):
+
+```bash
+cat ~/code/tt-agents/framework_comparison.md
+```
+
+**Resources:**
+
+- [smolagents docs](https://huggingface.co/docs/smolagents)
+- [OpenAI Agents SDK docs](https://openai.github.io/openai-agents-python/)
+- [CrewAI docs](https://docs.crewai.com)
+- [tt-inference-server](https://github.com/tenstorrent/tt-inference-server)
+- [Tenstorrent Discord](https://discord.gg/tenstorrent)

--- a/content/templates/agents/00_verify_tools.py
+++ b/content/templates/agents/00_verify_tools.py
@@ -74,8 +74,15 @@ def test_tool_call(client: openai.OpenAI, model: str) -> bool:
     )
     if has_tool_call:
         tc = choice.message.tool_calls[0]
-        args = json.loads(tc.function.arguments)
-        print(f"  ✓ Tool called: {tc.function.name}({args})")
+        try:
+            args = json.loads(tc.function.arguments)
+            print(f"  ✓ Tool called: {tc.function.name}({args})")
+        except json.JSONDecodeError:
+            raw = (tc.function.arguments or "")[:200]
+            print(f"  ✗ Tool called {tc.function.name!r}, but arguments were not valid JSON")
+            print(f"    Raw arguments: {raw}")
+            print("    Hint: check --tool-call-parser matches your model (hermes vs llama3_json)")
+            return False
     else:
         content = choice.message.content or ""
         print(f"  ✗ No tool call. finish_reason={choice.finish_reason!r}")

--- a/content/templates/agents/00_verify_tools.py
+++ b/content/templates/agents/00_verify_tools.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Verify tool calling works against the local vLLM endpoint.
+Run this first. If it fails, check your vLLM deployment flags:
+  --enable-auto-tool-choice --tool-call-parser hermes       (for Qwen3-32B)
+  --enable-auto-tool-choice --tool-call-parser llama3_json  (for Llama-3.3-70B)
+"""
+import sys
+import json
+import openai
+
+BASE_URL = "http://localhost:8000/v1"
+API_KEY = "none"
+
+
+def get_first_model(client: openai.OpenAI) -> str:
+    models = client.models.list()
+    if not models.data:
+        print("ERROR: No models found. Is vLLM running?")
+        sys.exit(1)
+    model_id = models.data[0].id
+    print(f"  Found model: {model_id}")
+    return model_id
+
+
+def test_basic_inference(client: openai.OpenAI, model: str) -> bool:
+    print("\n[1/3] Basic inference...")
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": "Say exactly: INFERENCE_OK"}],
+        max_tokens=20,
+    )
+    text = resp.choices[0].message.content or ""
+    ok = "INFERENCE_OK" in text
+    print(f"  {'✓' if ok else '✗'} Response: {text.strip()}")
+    return ok
+
+
+def test_tool_call(client: openai.OpenAI, model: str) -> bool:
+    print("\n[2/3] Tool call (function calling)...")
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                        "unit": {
+                            "type": "string",
+                            "enum": ["celsius", "fahrenheit"],
+                            "description": "Temperature unit",
+                        },
+                    },
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": "What's the weather in San Francisco?"}],
+        tools=tools,
+        tool_choice="auto",
+        max_tokens=200,
+    )
+    choice = resp.choices[0]
+    has_tool_call = (
+        choice.finish_reason == "tool_calls"
+        and choice.message.tool_calls is not None
+        and len(choice.message.tool_calls) > 0
+    )
+    if has_tool_call:
+        tc = choice.message.tool_calls[0]
+        args = json.loads(tc.function.arguments)
+        print(f"  ✓ Tool called: {tc.function.name}({args})")
+    else:
+        content = choice.message.content or ""
+        print(f"  ✗ No tool call. finish_reason={choice.finish_reason!r}")
+        print(f"    Content: {content[:200]}")
+    return has_tool_call
+
+
+def test_structured_output(client: openai.OpenAI, model: str) -> bool:
+    print("\n[3/3] Structured output (JSON mode)...")
+    resp = client.chat.completions.create(
+        model=model,
+        messages=[
+            {
+                "role": "user",
+                "content": 'Return a JSON object with keys "status" (string) and "count" (integer). Set status to "ok" and count to 42.',
+            }
+        ],
+        response_format={"type": "json_object"},
+        max_tokens=100,
+    )
+    text = resp.choices[0].message.content or ""
+    try:
+        data = json.loads(text)
+        ok = data.get("status") == "ok" and data.get("count") == 42
+        print(f"  {'✓' if ok else '✗'} Parsed JSON: {data}")
+        return ok
+    except json.JSONDecodeError:
+        print(f"  ✗ Not valid JSON: {text[:200]}")
+        return False
+
+
+def main():
+    print("=" * 60)
+    print("tt-agents: Tool Calling Verification")
+    print("=" * 60)
+    print(f"\nEndpoint: {BASE_URL}")
+
+    client = openai.OpenAI(base_url=BASE_URL, api_key=API_KEY)
+
+    try:
+        model = get_first_model(client)
+    except Exception as e:
+        print(f"ERROR connecting to {BASE_URL}: {e}")
+        print("\nMake sure vLLM is running:")
+        print("  cd ~/code/tt-inference-server")
+        print("  python3 run.py --model Qwen3-32B --tt-device p300x2 \\")
+        print("    --workflow server --docker-server --no-auth \\")
+        print("    --vllm-override-args '{\"enable_auto_tool_choice\": true, \"tool_call_parser\": \"hermes\"}'")
+        sys.exit(1)
+
+    results = {
+        "inference": test_basic_inference(client, model),
+        "tool_call": test_tool_call(client, model),
+        "structured": test_structured_output(client, model),
+    }
+
+    print("\n" + "=" * 60)
+    all_pass = all(results.values())
+    for name, ok in results.items():
+        print(f"  {'✓' if ok else '✗'} {name}")
+
+    if all_pass:
+        print("\n✅ All checks passed. Ready to run agent demos!")
+    else:
+        failed = [k for k, v in results.items() if not v]
+        print(f"\n❌ Failed: {failed}")
+        if "tool_call" in failed:
+            print("\nTool call failed. Check your vLLM flags:")
+            print("  For Qwen3-32B:     --tool-call-parser hermes")
+            print("  For Llama-3.3-70B: --tool-call-parser llama3_json")
+            print("  Both require:      --enable-auto-tool-choice")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/content/templates/agents/01_research_agent.py
+++ b/content/templates/agents/01_research_agent.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""
+Proof 1: Research Agent
+Framework: smolagents (HuggingFace)
+Model: Qwen3-32B (hermes tool parser) — or swap MODEL_ID for Llama-3.3-70B
+
+Demonstrates:
+  - Web search via DuckDuckGo
+  - Web page fetching and parsing
+  - Multi-step research synthesis
+  - ~60 lines of agent code
+
+Usage:
+  python3 01_research_agent.py                          (interactive topic picker)
+  python3 01_research_agent.py --headless               (auto-pick today's topic, no prompt)
+  python3 01_research_agent.py --query "your question"  (skip picker entirely)
+  python3 01_research_agent.py --model "meta-llama/Llama-3.3-70B-Instruct"
+
+Install deps:
+  pip install smolagents ddgs beautifulsoup4 markdownify requests
+"""
+import argparse
+import datetime
+import os
+import select
+import sys
+from pathlib import Path
+
+try:
+    from smolagents import CodeAgent, DuckDuckGoSearchTool, OpenAIServerModel, VisitWebpageTool
+except ImportError:
+    print("ERROR: smolagents not installed. Run: pip install smolagents ddgs")
+    sys.exit(1)
+
+BASE_URL = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-32B")
+RESEARCH_FILE = Path(__file__).parent / "last_research.txt"
+
+SUGGESTIONS = [
+    # Tech
+    (
+        "Python AI agent libraries",
+        "What Python libraries are most popular for building AI agents right now? "
+        "Compare smolagents, LangChain, AutoGen, and any strong newcomers — "
+        "with a real use case that shows each one's strengths."
+    ),
+    # Travel
+    (
+        "East Coast music festivals 2026",
+        "Which music festivals on the US East Coast are worth attending in spring, "
+        "summer, or fall 2026? Cover genre, vibe, rough ticket cost, and what "
+        "makes each one distinctly worth the trip."
+    ),
+    # Philosophy / AI
+    (
+        "Walter Benjamin on AI video and the prompt artist",
+        "Apply Walter Benjamin's theory of 'the aura' and mechanical reproduction "
+        "to AI video generation, deepfakes, and tools like Wan 2.2. What does it "
+        "mean to be an author when your primary creative act is writing a prompt?"
+    ),
+    # Home & Garden
+    (
+        "Attracting beneficial insects to any garden",
+        "What are the most effective ways to attract and keep beneficial insects — "
+        "ladybugs, lacewings, ground beetles — in a garden? Focus on strategies "
+        "that work across climates and don't require buying insects online."
+    ),
+    # Gaming / Classification
+    (
+        "Roguelike vs roguelite — genre lineage 1980–2026",
+        "What precisely distinguishes a 'roguelike' from a 'roguelite'? Trace the "
+        "genre from Rogue (1980) through the defining games of each decade, and "
+        "name the best example from each era with a one-sentence reason why."
+    ),
+    # Software discovery
+    (
+        "Best blog platforms for GitHub Pages in 2026",
+        "Which static site generators and blog platforms work best with GitHub Pages "
+        "hosting in 2026? Compare the top options on setup friction, theme quality, "
+        "writing experience, and long-term maintenance burden."
+    ),
+    # Creative / Game design
+    (
+        "Invent an original word puzzle mechanic",
+        "Design a word or language puzzle game mechanic that genuinely doesn't exist "
+        "yet. Describe the core rules, walk through a sample round, explain why it's "
+        "fun, and argue why no one has made it before."
+    ),
+    # My pick — outdoors / travel
+    (
+        "Underrated US national parks and public lands",
+        "What are the most underrated US national parks and public lands — places "
+        "that deliver a Yellowstone- or Yosemite-quality experience without the "
+        "crowds? For each, give the best season to visit and one thing most visitors miss."
+    ),
+]
+
+PROMPT_TIMEOUT = 10  # seconds to wait for input before auto-continuing
+
+
+def pick_topic(headless: bool) -> str:
+    # Rotate daily so each day highlights a different suggestion.
+    # Same suggestion for everyone on the same calendar day.
+    daily_idx = datetime.date.today().toordinal() % len(SUGGESTIONS)
+    label, query = SUGGESTIONS[daily_idx]
+
+    if headless:
+        print(f"[headless] Auto-selected: {label}")
+        return query
+
+    print("\nResearch topic — pick a number, paste your own query, or press Enter:\n")
+    for i, (lbl, _) in enumerate(SUGGESTIONS):
+        marker = "→" if i == daily_idx else " "
+        print(f"  {marker} [{i + 1}] {lbl}")
+
+    print(f"\n  Auto-continuing with [{daily_idx + 1}] in {PROMPT_TIMEOUT}s...")
+    print("> ", end="", flush=True)
+
+    ready = select.select([sys.stdin], [], [], PROMPT_TIMEOUT)[0]
+    user_input = sys.stdin.readline().strip() if ready else ""
+    print()
+
+    if not user_input:
+        return query
+
+    try:
+        n = int(user_input)
+        if 1 <= n <= len(SUGGESTIONS):
+            return SUGGESTIONS[n - 1][1]
+    except ValueError:
+        pass
+
+    return user_input  # treat any other text as a custom query
+
+
+def build_agent(model_id: str, verbose: bool = True) -> CodeAgent:
+    model = OpenAIServerModel(
+        model_id=model_id,
+        api_base=BASE_URL,
+        api_key="none",
+    )
+    # CodeAgent writes Python code to call tools — more robust than JSON tool calling.
+    # It handles multi-hop research naturally: search → read → search again → synthesize.
+    # Works even with imperfect tool calling configs because it generates executable code.
+    return CodeAgent(
+        tools=[DuckDuckGoSearchTool(), VisitWebpageTool()],
+        model=model,
+        max_steps=10,
+        verbosity_level=1 if verbose else 0,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Research agent demo (smolagents)")
+    parser.add_argument("--query", default=None, help="Research question (skips topic picker)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID on vLLM")
+    parser.add_argument("--quiet", action="store_true", help="Suppress step-by-step output")
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Skip interactive prompt — auto-pick today's topic and run immediately",
+    )
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("tt-agents Proof 1: Research Agent (smolagents)")
+    print("=" * 70)
+    print(f"Model:    {args.model}")
+    print(f"Endpoint: {BASE_URL}")
+
+    query = args.query if args.query else pick_topic(args.headless)
+
+    print(f"\nQuery:\n  {query}\n")
+    print("-" * 70)
+
+    agent = build_agent(args.model, verbose=not args.quiet)
+    result = agent.run(query)
+
+    print("\n" + "=" * 70)
+    print("FINAL RESULT:")
+    print("=" * 70)
+    print(result)
+    print(f"\n✓ Completed in {agent.step_number} steps")
+
+    # Save for the writing pipeline (03_writing_pipeline.py picks this up automatically)
+    RESEARCH_FILE.write_text(f"Topic: {query}\n\n{result}")
+    print(f"\n[Research saved → {RESEARCH_FILE.name}]")
+    print("[Tip: run 03_writing_pipeline.py next to turn this into any format you choose]")
+
+
+if __name__ == "__main__":
+    main()

--- a/content/templates/agents/02_code_explorer.py
+++ b/content/templates/agents/02_code_explorer.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Proof 2: Codebase Explorer
+Framework: OpenAI Agents SDK
+Model: Qwen3-32B (default) or Llama-3.3-70B-Instruct (--model flag)
+
+Demonstrates:
+  - Explicit JSON function calling (read_file, list_files, grep_code)
+  - File system navigation via tools
+  - Quality difference: 32B vs 70B visible on code comprehension tasks
+
+Usage:
+  python3 02_code_explorer.py
+  python3 02_code_explorer.py --dir ~/code/tt-inference-server/workflows
+  python3 02_code_explorer.py --model "meta-llama/Llama-3.3-70B-Instruct" --compare
+  python3 02_code_explorer.py --query "What API endpoints does this expose?"
+
+Install deps:
+  pip install openai-agents openai
+"""
+import argparse
+import asyncio
+import glob as _glob
+import os
+import re as _re
+import sys
+
+try:
+    from agents import Agent, Runner, function_tool, OpenAIChatCompletionsModel, set_trace_processors
+except ImportError:
+    print("ERROR: openai-agents not installed. Run: pip install openai-agents")
+    sys.exit(1)
+
+# Disable SDK tracing — we're local-only, there's no OpenAI API key to authenticate with
+set_trace_processors([])
+
+import openai
+
+BASE_URL = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-32B")
+MAX_FILE_BYTES = 32_000  # cap reads to avoid context overflow
+
+
+# --- Tools ---
+
+@function_tool
+def read_file(path: str) -> str:
+    """Read a text file from disk. Returns file contents (truncated at 32KB)."""
+    try:
+        path = os.path.expanduser(path)
+        if not os.path.isfile(path):
+            return f"ERROR: File not found: {path}"
+        with open(path, "r", errors="replace") as f:
+            content = f.read(MAX_FILE_BYTES)
+        if len(content) == MAX_FILE_BYTES:
+            content += "\n... [truncated at 32KB]"
+        return content
+    except Exception as e:
+        return f"ERROR reading {path}: {e}"
+
+
+@function_tool
+def list_files(directory: str, pattern: str = "*") -> str:
+    """List files in a directory matching an optional glob pattern (e.g. '*.py', '*.md')."""
+    try:
+        directory = os.path.expanduser(directory)
+        if not os.path.isdir(directory):
+            return f"ERROR: Directory not found: {directory}"
+        matches = _glob.glob(os.path.join(directory, pattern))
+        matches.sort()
+        if not matches:
+            return f"No files matching '{pattern}' in {directory}"
+        lines = [os.path.relpath(m, directory) for m in matches[:50]]
+        result = "\n".join(lines)
+        if len(matches) > 50:
+            result += f"\n... and {len(matches) - 50} more"
+        return result
+    except Exception as e:
+        return f"ERROR listing {directory}: {e}"
+
+
+@function_tool
+def grep_code(pattern: str, directory: str, file_extension: str = ".py") -> str:
+    """Search files in a directory for a regex pattern. Returns matching lines with file:line context."""
+    try:
+        directory = os.path.expanduser(directory)
+        if not os.path.isdir(directory):
+            return f"ERROR: Directory not found: {directory}"
+        results = []
+        for root, _, files in os.walk(directory):
+            for fname in sorted(files):
+                if not fname.endswith(file_extension):
+                    continue
+                fpath = os.path.join(root, fname)
+                try:
+                    with open(fpath, "r", errors="replace") as f:
+                        for i, line in enumerate(f, 1):
+                            if _re.search(pattern, line):
+                                rel = os.path.relpath(fpath, directory)
+                                results.append(f"{rel}:{i}: {line.rstrip()}")
+                                if len(results) >= 40:
+                                    results.append("... [limited to 40 matches]")
+                                    return "\n".join(results)
+                except OSError:
+                    continue
+        if not results:
+            return f"No matches for '{pattern}' in {directory} ({file_extension} files)"
+        return "\n".join(results)
+    except Exception as e:
+        return f"ERROR grepping {directory}: {e}"
+
+
+SYSTEM_PROMPT = """You are an expert code navigator with tools to read files, list directories, and search for patterns.
+
+When asked a question about a codebase:
+1. Use list_files and grep_code to locate relevant files
+2. Use read_file to examine the code in detail
+3. Answer precisely with file paths and line references for every claim
+
+Be concise and cite specific file:line locations."""
+
+
+def make_agent(model_id: str) -> Agent:
+    # Use OpenAIChatCompletionsModel so the SDK routes to our local vLLM endpoint
+    # instead of trying to resolve the model string as a provider prefix.
+    client = openai.AsyncOpenAI(base_url=BASE_URL, api_key="none")
+    model = OpenAIChatCompletionsModel(model=model_id, openai_client=client)
+    return Agent(
+        name="CodeExplorer",
+        instructions=SYSTEM_PROMPT,
+        tools=[read_file, list_files, grep_code],
+        model=model,
+    )
+
+
+async def run_query(agent: Agent, query: str) -> str:
+    result = await Runner.run(agent, query)
+    return result.final_output
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Codebase explorer agent demo (OpenAI Agents SDK)")
+    parser.add_argument(
+        "--dir",
+        default="~/code/tt-inference-server/workflows",
+        help="Directory to explore",
+    )
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID on vLLM")
+    parser.add_argument("--query", default=None, help="Custom question about the codebase")
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Run the same query with both Qwen3-32B and Llama-3.3-70B and compare output",
+    )
+    args = parser.parse_args()
+
+    target_dir = os.path.expanduser(args.dir)
+    default_query = (
+        f"Look in the directory {target_dir}. "
+        "Which LLM models support the P300X2 device? "
+        "For each model, what tool_call_parser_name is configured? "
+        "Show me the exact code lines that define this."
+    )
+    query = args.query or default_query
+
+    print("=" * 70)
+    print("tt-agents Proof 2: Codebase Explorer (OpenAI Agents SDK)")
+    print("=" * 70)
+    print(f"Endpoint: {BASE_URL}")
+    print(f"Directory: {target_dir}")
+    print(f"\nQuery:\n  {query}\n")
+
+    models = ["Qwen/Qwen3-32B", "meta-llama/Llama-3.3-70B-Instruct"] if args.compare else [args.model]
+
+    for model_id in models:
+        print(f"\n{'='*70}")
+        print(f"Model: {model_id}")
+        print("=" * 70)
+        agent = make_agent(model_id)
+        result = asyncio.run(run_query(agent, query))
+        print(result)
+
+    print("\n✓ Code exploration complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/content/templates/agents/02_code_explorer.py
+++ b/content/templates/agents/02_code_explorer.py
@@ -10,8 +10,8 @@ Demonstrates:
   - Quality difference: 32B vs 70B visible on code comprehension tasks
 
 Usage:
-  python3 02_code_explorer.py
-  python3 02_code_explorer.py --dir ~/code/tt-inference-server/workflows
+  python3 02_code_explorer.py                           (explores current directory)
+  python3 02_code_explorer.py --dir ~/code/myproject
   python3 02_code_explorer.py --model "meta-llama/Llama-3.3-70B-Instruct" --compare
   python3 02_code_explorer.py --query "What API endpoints does this expose?"
 
@@ -142,8 +142,8 @@ def main():
     parser = argparse.ArgumentParser(description="Codebase explorer agent demo (OpenAI Agents SDK)")
     parser.add_argument(
         "--dir",
-        default="~/code/tt-inference-server/workflows",
-        help="Directory to explore",
+        default=".",
+        help="Directory to explore (default: current working directory)",
     )
     parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID on vLLM")
     parser.add_argument("--query", default=None, help="Custom question about the codebase")
@@ -154,12 +154,12 @@ def main():
     )
     args = parser.parse_args()
 
-    target_dir = os.path.expanduser(args.dir)
+    target_dir = os.path.abspath(os.path.expanduser(args.dir))
     default_query = (
-        f"Look in the directory {target_dir}. "
-        "Which LLM models support the P300X2 device? "
-        "For each model, what tool_call_parser_name is configured? "
-        "Show me the exact code lines that define this."
+        f"Explore the directory {target_dir}. "
+        "Summarize what this codebase does, how it is organized, "
+        "and which files are most important to understand first. "
+        "List the top 5 files with a one-sentence description of each."
     )
     query = args.query or default_query
 

--- a/content/templates/agents/03_writing_pipeline.py
+++ b/content/templates/agents/03_writing_pipeline.py
@@ -102,9 +102,6 @@ FORMATS = [
     ),
 ]
 
-PROMPT_TIMEOUT = 10
-
-
 def pick_format(headless: bool) -> tuple[str, str]:
     daily_idx = datetime.date.today().toordinal() % len(FORMATS)
     label, instruction = FORMATS[daily_idx]

--- a/content/templates/agents/03_writing_pipeline.py
+++ b/content/templates/agents/03_writing_pipeline.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""
+Proof 3: Multi-Agent Writing Pipeline
+Framework: CrewAI
+Model: Qwen3-32B
+
+If 01_research_agent.py has been run first, its output is loaded automatically
+and the Researcher agent is skipped — the pipeline goes straight to Writer → Editor
+with real research already in hand.
+
+If no prior research exists, the full three-agent pipeline runs:
+  Researcher → Writer → Editor
+
+Either way, a format picker lets you choose HOW the piece is written:
+  blog post, tweet thread, ELI5, devil's advocate, lyrical prose,
+  exec one-pager, Reddit thread, or your own instruction.
+
+Usage:
+  python3 03_writing_pipeline.py                          (picks up last_research.txt if present)
+  python3 03_writing_pipeline.py --topic "your topic"     (ignore saved research, research fresh)
+  python3 03_writing_pipeline.py --no-research            (force fresh research even if file exists)
+  python3 03_writing_pipeline.py --headless               (no prompts, auto-pick format)
+  python3 03_writing_pipeline.py --model "meta-llama/Llama-3.3-70B-Instruct"
+
+Install deps:
+  pip install crewai openai
+"""
+import argparse
+import datetime
+import importlib.util
+import os
+import select
+import sys
+from pathlib import Path
+
+try:
+    from crewai import Agent, Crew, LLM, Process, Task
+except ImportError:
+    print("ERROR: crewai not installed. Run: pip install crewai")
+    sys.exit(1)
+
+BASE_URL = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen3-32B")
+RESEARCH_FILE = Path(__file__).parent / "last_research.txt"
+PROMPT_TIMEOUT = 10
+
+DEFAULT_TOPIC = (
+    "Running AI agents locally on open hardware: "
+    "why 32B+ parameter models change everything for agent reliability"
+)
+
+FORMATS = [
+    (
+        "Developer blog post",
+        "Write a structured 600-900 word blog post for a technical developer audience. "
+        "Use specific facts and numbers. Short paragraphs (3-4 sentences max). "
+        "Include at least one concrete code example or command if it fits naturally. "
+        "End with a clear call to action.",
+    ),
+    (
+        "Tweet thread (≤140 chars each)",
+        "Write a thread of 10-14 tweets. EVERY tweet must be ≤140 characters. "
+        "Number them 1/N through N/N. Each must stand alone if quote-tweeted. "
+        "Open with a hook tweet that earns the follow. Close with a punchy summary. "
+        "No filler, no 'great thread!' tweets.",
+    ),
+    (
+        "Explain it like I'm curious but new",
+        "Write for someone who is genuinely curious and intelligent but has zero "
+        "prior knowledge of this topic. No jargon without definition. Use analogies "
+        "liberally. Make it feel like a conversation with a knowledgeable friend, "
+        "not a lecture. Aim for 400-600 warm, readable words.",
+    ),
+    (
+        "Devil's advocate — argue the opposite",
+        "Write a skeptical, contrarian take. Steelman the subject first (one paragraph), "
+        "then systematically challenge it. Find the weaknesses, the hype, the things "
+        "that could go wrong or that the enthusiasts are glossing over. 400-600 words. "
+        "End with a clear statement of what evidence would change your mind.",
+    ),
+    (
+        "Lyrical / prose poetry",
+        "Write this as literary nonfiction or prose poetry. Prioritize beauty of "
+        "language, rhythm, and surprise over comprehensiveness. Let the form reflect "
+        "the content. Aim for 300-500 words that someone would want to read aloud. "
+        "Every sentence should earn its place.",
+    ),
+    (
+        "Executive one-pager",
+        "Write a single-page briefing for a decision-maker with 90 seconds. "
+        "Lead with a one-sentence summary of the situation. Three bullet points "
+        "of essential context. One paragraph recommendation that names the most "
+        "important tradeoff explicitly. No jargon, no filler, fits on one page.",
+    ),
+    (
+        "Reddit thread — multiple POVs",
+        "Write it as a Reddit-style discussion. Start with a top-level post (2-3 paragraphs). "
+        "Follow with 5 reply comments from distinct, authentic-feeling personas: "
+        "an enthusiast, a skeptic, a practitioner with real experience, a complete "
+        "newcomer with a naive but honest question, and someone with an unexpected "
+        "angle nobody else mentioned. Each voice should feel like a real person.",
+    ),
+]
+
+PROMPT_TIMEOUT = 10
+
+
+def pick_format(headless: bool) -> tuple[str, str]:
+    daily_idx = datetime.date.today().toordinal() % len(FORMATS)
+    label, instruction = FORMATS[daily_idx]
+
+    if headless:
+        print(f"[headless] Auto-selected format: {label}")
+        return label, instruction
+
+    print("\nWriting format — pick a number, paste your own instruction, or press Enter:\n")
+    for i, (lbl, _) in enumerate(FORMATS):
+        marker = "→" if i == daily_idx else " "
+        print(f"  {marker} [{i + 1}] {lbl}")
+
+    print(f"\n  Auto-continuing with [{daily_idx + 1}] in {PROMPT_TIMEOUT}s...")
+    print("> ", end="", flush=True)
+
+    ready = select.select([sys.stdin], [], [], PROMPT_TIMEOUT)[0]
+    user_input = sys.stdin.readline().strip() if ready else ""
+    print()
+
+    if not user_input:
+        return label, instruction
+
+    try:
+        n = int(user_input)
+        if 1 <= n <= len(FORMATS):
+            return FORMATS[n - 1]
+    except ValueError:
+        pass
+
+    return "Custom instruction", user_input
+
+
+def load_research() -> str | None:
+    if RESEARCH_FILE.exists():
+        return RESEARCH_FILE.read_text().strip()
+    return None
+
+
+def run_research_agent(model_id: str) -> str:
+    """Run script 01's research pipeline to generate last_research.txt, then return the result."""
+    script_path = Path(__file__).parent / "01_research_agent.py"
+    spec = importlib.util.spec_from_file_location("research_agent", script_path)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+
+    print("\n[No saved research found — starting from the research agent]")
+    print("[Running 01_research_agent.py first. The result will be available next time too.]\n")
+    print("-" * 70)
+
+    query = m.pick_topic(headless=False)
+
+    print(f"\nResearch query:\n  {query}\n")
+    print("-" * 70)
+
+    agent = m.build_agent(model_id, verbose=True)
+    result = agent.run(query)
+
+    print("\n" + "=" * 70)
+    print("RESEARCH COMPLETE:")
+    print("=" * 70)
+    print(result)
+    print(f"\n✓ Research done in {agent.step_number} steps")
+    print("-" * 70)
+
+    full_text = f"Topic: {query}\n\n{result}"
+    m.RESEARCH_FILE.write_text(full_text)
+    print(f"[Research saved → {m.RESEARCH_FILE.name}]\n")
+    return full_text
+
+
+def build_crew(model_id: str, topic: str, format_label: str, format_instruction: str,
+               existing_research: str | None) -> Crew:
+    llm = LLM(
+        model=f"openai/{model_id}",
+        base_url=BASE_URL,
+        api_key="none",
+        temperature=0.7,
+        max_tokens=2048,
+    )
+
+    writer = Agent(
+        role="Technical Writer",
+        goal="Transform research into a compelling piece in the requested format",
+        backstory=(
+            "You are a skilled writer who adapts style, tone, and format to match "
+            "any brief. You write with clarity, use concrete examples from the research, "
+            "and never invent facts not provided to you."
+        ),
+        llm=llm,
+        verbose=True,
+        allow_delegation=False,
+    )
+
+    editor = Agent(
+        role="Senior Editor",
+        goal="Polish the piece so every sentence earns its place",
+        backstory=(
+            "You are a demanding editor who cuts redundant sentences, strengthens the "
+            "opening, verifies the format instruction was followed exactly, and ensures "
+            "the ending lands. You return only the final polished piece."
+        ),
+        llm=llm,
+        verbose=True,
+        allow_delegation=False,
+    )
+
+    if existing_research:
+        # Research already done — go straight to writing
+        writing_task = Task(
+            description=(
+                f"Write a piece about the following topic using the research provided below.\n\n"
+                f"FORMAT INSTRUCTION — follow this exactly:\n{format_instruction}\n\n"
+                f"RESEARCH (do not invent facts outside this):\n{existing_research}"
+            ),
+            agent=writer,
+            expected_output=f"A complete piece in this format: {format_label}",
+        )
+    else:
+        # No prior research — include a Researcher
+        researcher = Agent(
+            role="Research Specialist",
+            goal="Gather accurate, specific facts and create a detailed outline",
+            backstory=(
+                "You are a meticulous researcher who finds concrete facts, statistics, "
+                "and examples. You never make up numbers. You create structured outlines "
+                "that writers can follow precisely."
+            ),
+            llm=llm,
+            verbose=True,
+            allow_delegation=False,
+        )
+
+        research_task = Task(
+            description=(
+                f"Research the topic: '{topic}'\n\n"
+                "Produce:\n"
+                "1. A hook opening sentence that stops a skeptical technical reader mid-scroll\n"
+                "2. 5-7 bullet points of specific, factual supporting points\n"
+                "   (include numbers/benchmarks where you know them)\n"
+                "3. A suggested 5-section outline with one sentence per section\n"
+                "4. A strong concluding argument\n\n"
+                "Be specific. Cite the 7B vs 32B+ agent reliability difference if relevant."
+            ),
+            agent=researcher,
+            expected_output="A structured research document with hook, key facts, outline, and conclusion",
+        )
+
+        writing_task = Task(
+            description=(
+                f"Using the research document above, write a piece on this topic.\n\n"
+                f"FORMAT INSTRUCTION — follow this exactly:\n{format_instruction}\n\n"
+                "Do NOT invent facts not in the research document."
+            ),
+            agent=writer,
+            expected_output=f"A complete piece in this format: {format_label}",
+            context=[research_task],
+        )
+
+        editing_task = Task(
+            description=(
+                f"Edit the piece. Verify the format instruction was followed exactly:\n"
+                f"{format_instruction}\n\n"
+                "Cut redundant sentences (aim for 10% reduction). "
+                "Strengthen the opening. Ensure the ending lands. "
+                "Return only the final polished piece, ready to post."
+            ),
+            agent=editor,
+            expected_output="Final polished piece, ready to publish",
+            context=[writing_task],
+        )
+
+        return Crew(
+            agents=[researcher, writer, editor],
+            tasks=[research_task, writing_task, editing_task],
+            process=Process.sequential,
+            verbose=True,
+        )
+
+    # 2-agent path when research was pre-loaded
+    editing_task = Task(
+        description=(
+            f"Edit the piece. Verify the format instruction was followed exactly:\n"
+            f"{format_instruction}\n\n"
+            "Cut redundant sentences (aim for 10% reduction). "
+            "Strengthen the opening. Ensure the ending lands. "
+            "Return only the final polished piece, ready to post."
+        ),
+        agent=editor,
+        expected_output="Final polished piece, ready to publish",
+        context=[writing_task],
+    )
+
+    return Crew(
+        agents=[writer, editor],
+        tasks=[writing_task, editing_task],
+        process=Process.sequential,
+        verbose=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-agent writing pipeline demo (CrewAI)")
+    parser.add_argument("--topic", default=None,
+                        help="Topic to research and write about (skips saved research)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID on vLLM")
+    parser.add_argument("--no-research", action="store_true",
+                        help="Ignore last_research.txt and run the full Researcher → Writer → Editor pipeline")
+    parser.add_argument("--headless", action="store_true",
+                        help="Skip format picker — auto-select today's format and run immediately")
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("tt-agents Proof 3: Multi-Agent Writing Pipeline (CrewAI)")
+    print("=" * 70)
+    print(f"Model:    {args.model}")
+    print(f"Endpoint: {BASE_URL}")
+
+    # Determine research source
+    existing_research = None
+    topic = args.topic or DEFAULT_TOPIC
+
+    if args.topic:
+        # Explicit topic — research fresh, skip the file
+        pass
+    elif args.no_research:
+        # Force the 3-agent Researcher path with default topic
+        pass
+    else:
+        existing_research = load_research()
+        if not existing_research:
+            # No saved research — run script 01 first, then use its output
+            existing_research = run_research_agent(args.model)
+
+    if existing_research:
+        first_line = existing_research.splitlines()[0][:80]
+        age = ""
+        if RESEARCH_FILE.exists():
+            import time
+            secs = time.time() - RESEARCH_FILE.stat().st_mtime
+            age = f" ({int(secs // 60)} min ago)" if secs < 3600 else f" ({int(secs // 3600)}h ago)"
+        print(f"\n[Research loaded from {RESEARCH_FILE.name}{age}]")
+        print(f"  {first_line}...")
+        print("  (Pipeline: Writer → Editor  |  pass --no-research to run fresh Researcher instead)")
+    else:
+        print(f"\nTopic: {topic}")
+        print("  (Pipeline: Researcher → Writer → Editor)")
+
+    format_label, format_instruction = pick_format(args.headless)
+
+    print(f"\nFormat: {format_label}")
+    print("-" * 70)
+
+    crew = build_crew(args.model, topic, format_label, format_instruction, existing_research)
+    result = crew.kickoff()
+
+    print("\n" + "=" * 70)
+    print("FINAL PIECE:")
+    print("=" * 70)
+    print(result.raw if hasattr(result, "raw") else str(result))
+    print("\n✓ Pipeline complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/content/templates/agents/04_dungeon_master.py
+++ b/content/templates/agents/04_dungeon_master.py
@@ -42,9 +42,14 @@ from pathlib import Path
 try:
     from smolagents import OpenAIServerModel, ToolCallingAgent, tool
     from smolagents.monitoring import AgentLogger, LogLevel
-    from rich.panel import Panel
 except ImportError:
     print("ERROR: smolagents not installed. Run: pip install smolagents")
+    sys.exit(1)
+
+try:
+    from rich.panel import Panel
+except ImportError:
+    print("ERROR: rich not installed. Run: pip install rich")
     sys.exit(1)
 
 

--- a/content/templates/agents/04_dungeon_master.py
+++ b/content/templates/agents/04_dungeon_master.py
@@ -334,32 +334,34 @@ def check_rules(action: str) -> str:
 DM_SYSTEM_PROMPT = """You are a creative, atmospheric Dungeon Master running a text adventure set in the town of Millhaven.
 
 CORE RULES:
-1. Call get_player_status() at the start of EVERY turn before narrating
-2. Call move_player() with the exact location ID when the player travels
-3. Call pick_up_item() with the exact item name when picking up items
-4. For combat: call roll_dice() for attacks (d20), call update_player_hp() for all HP changes
-5. Call update_player_gold() for all gold transactions
-6. Never invent locations, items, or exits not in the world state
+1. Call get_player_status() ONCE per turn, before narrating any scene change, movement, combat,
+   or item interaction. Call it exactly once — do not repeat it within a single turn.
+   For pure dialogue or simple verbal responses, you may skip it.
+2. Call move_player() with the exact location ID when the player travels.
+3. Call pick_up_item() with the exact item name when picking up items.
+4. For combat: call roll_dice() for attacks (d20), call update_player_hp() for all HP changes.
+5. Call update_player_gold() for all gold transactions.
+6. Never invent locations, items, or exits not in the world state.
 
 CREATIVE TOOLS — use these to build living, consistent world content:
-7. cast_spell(spell_name, target) — when player casts; consumes a slot, returns mechanical effect
-8. examine_item(item_name) — when player inspects closely; reveals hidden properties
-9. manage_lore(subject, description) — RECORD lore when you invent backstory, NPC personality, or secrets;
-   RETRIEVE it on later turns by calling with no description. This keeps your world consistent.
-10. check_rules(action) — call before resolving unusual or ambiguous actions
+7. cast_spell(spell_name, target) — when player casts; consumes a slot, returns mechanical effect.
+8. examine_item(item_name) — when player inspects closely; reveals hidden properties.
+9. manage_lore(subject, description) — RECORD lore when you invent backstory, NPC personality, or
+   secrets; RETRIEVE it on later turns by calling with only subject. Keeps the world consistent.
+10. check_rules(action) — call before resolving unusual or ambiguous actions.
 
-LORE WORKFLOW (important):
-- When you give an NPC a personality or backstory, immediately call manage_lore('npc_name', '...')
-- When you invent a fact about a location or item, call manage_lore to save it
-- Before describing an NPC you've met before, call manage_lore to retrieve what you recorded
+LORE WORKFLOW:
+- When you give an NPC a personality or backstory, call manage_lore('npc_name', '...') immediately.
+- Before describing an NPC you've met before, call manage_lore('npc_name') to retrieve what you recorded.
+- Limit yourself to 1-2 lore calls per turn — record the most important new fact, not every detail.
 
 STYLE:
-- Write vivid, atmospheric descriptions (2-4 sentences per response)
-- NPCs should feel like real people with histories — use manage_lore to make them consistent
-- Make combat tense and specific: describe the attack, the hit, the consequence
-- Items with hidden properties (examine_item) should feel like small discoveries
-- The world has secrets — the crypt runes, the mysterious coin, the torn journal all connect
-- Match tone to situation: warm in the tavern, ominous in the crypt, tense in combat
+- Write vivid, atmospheric descriptions (2-4 sentences per response).
+- NPCs should feel like real people with histories — use manage_lore to make them consistent.
+- Make combat tense and specific: describe the attack, the hit, the consequence.
+- Items with hidden properties (examine_item) should feel like small discoveries.
+- The world has secrets — the crypt runes, the mysterious coin, the torn journal all connect.
+- Match tone to situation: warm in the tavern, ominous in the crypt, tense in combat.
 
 Begin by calling get_player_status(), then describe the opening scene."""
 
@@ -410,8 +412,8 @@ def main():
         ],
         model=model,
         instructions=DM_SYSTEM_PROMPT,
-        max_steps=10,
-        verbosity_level=0,
+        max_steps=15,
+        verbosity_level=1,
     )
 
     print("\nThe DM is setting the scene...\n")
@@ -419,7 +421,7 @@ def main():
         "Describe the starting area and greet the player. Check their status first.",
         reset=True,
     )
-    print(f"DM: {response}\n")
+    print(f"\nDM: {response}\n")
 
     while True:
         try:
@@ -459,10 +461,10 @@ def main():
                 print("[No lore recorded yet — explore and interact to build the world]\n")
             continue
 
-        print("\nDM: ", end="", flush=True)
+        print()
         try:
             response = agent.run(f"Player action: {user_input}", reset=False)
-            print(f"{response}\n")
+            print(f"\nDM: {response}\n")
         except Exception as e:
             print(f"[Error: {e}]\n")
             continue

--- a/content/templates/agents/04_dungeon_master.py
+++ b/content/templates/agents/04_dungeon_master.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+Proof 4: Dungeon Master Agent
+Framework: smolagents ToolCallingAgent (with persistent JSON state)
+Model: Llama-3.3-70B-Instruct (recommended for narrative quality)
+       Qwen3-32B also works, slightly faster
+
+Demonstrates:
+  - Stateful multi-turn agents (world.json persists between sessions)
+  - Tool-backed narrative consistency (DM can't invent things)
+  - Creating new tools by naming them and writing a docstring
+  - The 70B quality difference on creative/reasoning tasks
+
+The tools here range from mechanical (roll_dice, update_player_hp) to
+creative (manage_lore, examine_item). Each new tool is ~10-15 lines:
+a name, a docstring the model reads, and a function body that touches
+world state. The model figures out when and how to use each one.
+
+Usage:
+  python3 04_dungeon_master.py
+  python3 04_dungeon_master.py --model "Qwen/Qwen3-32B"
+  python3 04_dungeon_master.py --reset     (start fresh from world.json)
+
+Controls:
+  Type your action at the > prompt
+  Type 'status'  — see your current stats and spell slots
+  Type 'lore'    — see everything the DM has recorded about the world
+  Type 'quit'    — exit and save
+  Ctrl+C         — emergency exit
+
+Install deps:
+  pip install smolagents
+"""
+import argparse
+import json
+import os
+import random
+import sys
+from pathlib import Path
+
+try:
+    from smolagents import OpenAIServerModel, ToolCallingAgent, tool
+except ImportError:
+    print("ERROR: smolagents not installed. Run: pip install smolagents")
+    sys.exit(1)
+
+BASE_URL = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
+DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
+WORLD_FILE = Path(__file__).parent / "world.json"
+SESSION_FILE = Path(__file__).parent / "world_session.json"
+
+# Module-level world state — shared across all @tool functions
+_world_state: dict = {}
+
+
+# ── World state helpers ───────────────────────────────────────────────────────
+
+def load_world(reset: bool = False) -> dict:
+    source = WORLD_FILE if (reset or not SESSION_FILE.exists()) else SESSION_FILE
+    with open(source) as f:
+        return json.load(f)
+
+
+def save_world(world: dict) -> None:
+    with open(SESSION_FILE, "w") as f:
+        json.dump(world, f, indent=2)
+
+
+# ── Core state tools ──────────────────────────────────────────────────────────
+
+@tool
+def get_player_status() -> str:
+    """Get the player's current HP, gold, inventory, spell slots, and location with exits and items present.
+    Call this at the start of every turn before narrating anything.
+    """
+    p = _world_state["player"]
+    loc = _world_state["locations"].get(p["location"], {})
+    return json.dumps({
+        "name": p["name"],
+        "hp": f"{p['hp']}/{p['max_hp']}",
+        "gold": p["gold"],
+        "inventory": p["inventory"],
+        "spellbook": p.get("spellbook", []),
+        "spell_slots": p.get("spell_slots", {}),
+        "location": loc.get("name", p["location"]),
+        "location_description": loc.get("description", ""),
+        "exits": loc.get("exits", []),
+        "items_here": loc.get("items", []),
+        "npcs_here": loc.get("npcs", []),
+    }, indent=2)
+
+
+@tool
+def move_player(destination: str) -> str:
+    """Move the player to a new location. Must be one of the current location's exits.
+
+    Args:
+        destination: The location ID to move to (e.g. 'rusty_axe', 'library', 'crypt').
+    """
+    p = _world_state["player"]
+    current_loc = _world_state["locations"].get(p["location"], {})
+    exits = current_loc.get("exits", [])
+    if destination not in exits:
+        available = ", ".join(exits) if exits else "none"
+        return f"Cannot move to '{destination}'. Available exits: {available}"
+    p["location"] = destination
+    new_loc = _world_state["locations"].get(destination, {})
+    _world_state["turn"] += 1
+    save_world(_world_state)
+    return json.dumps({
+        "moved_to": new_loc.get("name", destination),
+        "description": new_loc.get("description", ""),
+        "items_here": new_loc.get("items", []),
+        "npcs_here": new_loc.get("npcs", []),
+        "exits": new_loc.get("exits", []),
+    }, indent=2)
+
+
+@tool
+def pick_up_item(item_name: str) -> str:
+    """Pick up an item from the current location and add it to the player's inventory.
+
+    Args:
+        item_name: The exact name of the item to pick up (must be present in current location).
+    """
+    p = _world_state["player"]
+    loc = _world_state["locations"].get(p["location"], {})
+    items = loc.get("items", [])
+    if item_name not in items:
+        available = ", ".join(items) if items else "none"
+        return f"Item '{item_name}' not found here. Items available: {available}"
+    items.remove(item_name)
+    p["inventory"].append(item_name)
+    _world_state["turn"] += 1
+    save_world(_world_state)
+    return f"Picked up '{item_name}'. Inventory: {p['inventory']}"
+
+
+@tool
+def roll_dice(sides: int, count: int = 1, modifier: int = 0) -> str:
+    """Roll dice for combat, skill checks, or any random outcome. Returns individual rolls and total.
+
+    Args:
+        sides: Number of sides on the die. Must be 4, 6, 8, 10, 12, 20, or 100.
+        count: Number of dice to roll (default 1, max 10).
+        modifier: Flat bonus or penalty added to the total (default 0).
+    """
+    if sides not in (4, 6, 8, 10, 12, 20, 100):
+        return f"Invalid dice: d{sides}. Use d4, d6, d8, d10, d12, d20, or d100."
+    rolls = [random.randint(1, sides) for _ in range(max(1, min(count, 10)))]
+    total = sum(rolls) + modifier
+    mod_str = f" + {modifier}" if modifier > 0 else (f" - {abs(modifier)}" if modifier < 0 else "")
+    return f"Rolled {count}d{sides}{mod_str}: {rolls} = {total}"
+
+
+@tool
+def update_player_hp(change: int, reason: str) -> str:
+    """Modify player HP. Negative values deal damage, positive values heal.
+
+    Args:
+        change: HP change amount (negative = damage, positive = healing).
+        reason: Short description of why HP changed (e.g. 'goblin attack', 'healing potion').
+    """
+    p = _world_state["player"]
+    old_hp = p["hp"]
+    p["hp"] = max(0, min(p["max_hp"], p["hp"] + change))
+    save_world(_world_state)
+    status = "alive" if p["hp"] > 0 else "DEAD"
+    return f"HP: {old_hp} → {p['hp']}/{p['max_hp']} ({reason}) [{status}]"
+
+
+@tool
+def update_player_gold(change: int, reason: str) -> str:
+    """Add or remove gold from the player's purse.
+
+    Args:
+        change: Gold change amount (negative = spending, positive = earning).
+        reason: Short description of the transaction (e.g. 'bought potion', 'found treasure').
+    """
+    p = _world_state["player"]
+    old_gold = p["gold"]
+    p["gold"] = max(0, p["gold"] + change)
+    save_world(_world_state)
+    return f"Gold: {old_gold} → {p['gold']} ({reason})"
+
+
+# ── Creative / generative tools ───────────────────────────────────────────────
+# These tools show the second half of the pattern: tools that CREATE new material.
+# The model calls them to generate content it then weaves into the narrative.
+# Adding a new one takes ~10 lines: name it, describe it, touch world state.
+
+@tool
+def cast_spell(spell_name: str, target: str) -> str:
+    """Cast a spell from the player's spellbook at a target. Consumes a spell slot.
+    Returns the spell's mechanical effect — narrate it vividly.
+
+    Args:
+        spell_name: Name of the spell (e.g. 'magic_missile', 'healing_word', 'shield').
+        target: What or who the spell is targeting (e.g. 'the goblin', 'myself').
+    """
+    p = _world_state["player"]
+    spellbook = p.get("spellbook", [])
+    if spell_name not in spellbook:
+        known = ", ".join(spellbook) if spellbook else "none"
+        return f"'{spell_name}' is not in your spellbook. Known spells: {known}"
+
+    spells = _world_state.get("spells", {})
+    spell = spells.get(spell_name)
+    if not spell:
+        return f"Spell '{spell_name}' has no definition in the world. Cannot cast."
+
+    slot_level = str(spell["slot"])
+    slots = p.get("spell_slots", {})
+    if slots.get(slot_level, 0) <= 0:
+        return f"No level-{slot_level} spell slots remaining. Rest to recover slots."
+
+    slots[slot_level] -= 1
+    p["spell_slots"] = slots
+    _world_state["turn"] += 1
+    save_world(_world_state)
+
+    effect_parts = [f"Cast '{spell_name}' at {target}.", spell["description"]]
+    if "damage" in spell:
+        effect_parts.append(f"Deals up to {spell['damage']} damage.")
+    if "heal" in spell:
+        effect_parts.append(f"Restores up to {spell['heal']} HP.")
+    if "effect" in spell:
+        effect_parts.append(f"Effect: {spell['effect']}.")
+    effect_parts.append(f"Slots remaining: {slots}")
+    return " ".join(effect_parts)
+
+
+@tool
+def examine_item(item_name: str) -> str:
+    """Examine an item closely to reveal its full description and hidden properties.
+    Call this when a player inspects an item carefully — it reveals more than a glance would.
+
+    Args:
+        item_name: Name of the item to examine (must be in inventory or present in the current location).
+    """
+    p = _world_state["player"]
+    loc = _world_state["locations"].get(p["location"], {})
+    accessible = p["inventory"] + loc.get("items", [])
+    if item_name not in accessible:
+        return f"'{item_name}' is not in your inventory or in this location."
+
+    details = _world_state.get("item_details", {}).get(item_name)
+    if not details:
+        return f"You examine the {item_name}. It appears to be exactly what it looks like."
+
+    return json.dumps({
+        "item": item_name,
+        "description": details.get("description", ""),
+        "hidden_properties": details.get("hidden", "Nothing unusual revealed."),
+    }, indent=2)
+
+
+@tool
+def manage_lore(subject: str, description: str = "") -> str:
+    """Record or retrieve lore about any person, place, object, or event.
+
+    The DM should call this to:
+    - RECORD: When inventing backstory, NPC personality, history, or secrets — pass both subject and description.
+    - RETRIEVE: When recalling previously established facts — pass only subject.
+
+    This keeps the world consistent across turns. If you invented something, record it.
+
+    Args:
+        subject: The person, place, or thing this lore describes (e.g. 'barkeep', 'the rusty key', 'crypt runes').
+        description: The lore to record (1-3 sentences). Leave empty to look up existing lore.
+    """
+    lore = _world_state.setdefault("lore", {})
+    key = subject.lower().strip()
+
+    if description:
+        lore[key] = description
+        save_world(_world_state)
+        return f"Lore recorded — {subject}: {description}"
+
+    existing = lore.get(key)
+    if existing:
+        return f"Established lore — {subject}: {existing}"
+    return f"No lore recorded for '{subject}' yet. Invent it now and call manage_lore to save it."
+
+
+@tool
+def check_rules(action: str) -> str:
+    """Validate whether a player action is possible given current world state.
+    Call this before resolving any unusual, risky, or potentially invalid action.
+    Returns what's mechanically possible and any relevant constraints.
+
+    Args:
+        action: The action the player wants to take (e.g. 'pick the lock', 'cast fireball', 'bribe the guard').
+    """
+    p = _world_state["player"]
+    loc = _world_state["locations"].get(p["location"], {})
+
+    if p["hp"] <= 0:
+        return "Player is dead. No actions possible."
+
+    action_lower = action.lower()
+    notes = []
+
+    if any(w in action_lower for w in ("cast", "spell", "magic")):
+        slots = p.get("spell_slots", {})
+        total_slots = sum(slots.values())
+        known = p.get("spellbook", [])
+        notes.append(f"Spells known: {', '.join(known) or 'none'}")
+        notes.append(f"Spell slots remaining: {slots} (total: {total_slots})")
+        if total_slots == 0:
+            notes.append("WARNING: No spell slots. Player must rest to cast again.")
+
+    if any(w in action_lower for w in ("attack", "fight", "strike", "hit")):
+        npcs = loc.get("npcs", [])
+        notes.append(f"Entities present: {', '.join(npcs) or 'none'}")
+        has_weapon = any(w in p["inventory"] for w in ("short sword", "dagger", "axe", "staff"))
+        notes.append(f"Has melee weapon: {has_weapon}")
+
+    if any(w in action_lower for w in ("pick up", "take", "grab")):
+        items_here = loc.get("items", [])
+        notes.append(f"Items available here: {', '.join(items_here) or 'none'}")
+
+    if any(w in action_lower for w in ("move", "go", "travel", "walk")):
+        notes.append(f"Available exits: {', '.join(loc.get('exits', [])) or 'none'}")
+
+    result = f"Action '{action}' is mechanically possible."
+    if notes:
+        result += "\nContext:\n" + "\n".join(f"  • {n}" for n in notes)
+    return result
+
+
+# ── System prompt ─────────────────────────────────────────────────────────────
+
+DM_SYSTEM_PROMPT = """You are a creative, atmospheric Dungeon Master running a text adventure set in the town of Millhaven.
+
+CORE RULES:
+1. Call get_player_status() at the start of EVERY turn before narrating
+2. Call move_player() with the exact location ID when the player travels
+3. Call pick_up_item() with the exact item name when picking up items
+4. For combat: call roll_dice() for attacks (d20), call update_player_hp() for all HP changes
+5. Call update_player_gold() for all gold transactions
+6. Never invent locations, items, or exits not in the world state
+
+CREATIVE TOOLS — use these to build living, consistent world content:
+7. cast_spell(spell_name, target) — when player casts; consumes a slot, returns mechanical effect
+8. examine_item(item_name) — when player inspects closely; reveals hidden properties
+9. manage_lore(subject, description) — RECORD lore when you invent backstory, NPC personality, or secrets;
+   RETRIEVE it on later turns by calling with no description. This keeps your world consistent.
+10. check_rules(action) — call before resolving unusual or ambiguous actions
+
+LORE WORKFLOW (important):
+- When you give an NPC a personality or backstory, immediately call manage_lore('npc_name', '...')
+- When you invent a fact about a location or item, call manage_lore to save it
+- Before describing an NPC you've met before, call manage_lore to retrieve what you recorded
+
+STYLE:
+- Write vivid, atmospheric descriptions (2-4 sentences per response)
+- NPCs should feel like real people with histories — use manage_lore to make them consistent
+- Make combat tense and specific: describe the attack, the hit, the consequence
+- Items with hidden properties (examine_item) should feel like small discoveries
+- The world has secrets — the crypt runes, the mysterious coin, the torn journal all connect
+- Match tone to situation: warm in the tavern, ominous in the crypt, tense in combat
+
+Begin by calling get_player_status(), then describe the opening scene."""
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    global _world_state
+
+    parser = argparse.ArgumentParser(description="Dungeon master agent demo (smolagents)")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="Model ID on vLLM")
+    parser.add_argument("--reset", action="store_true", help="Reset to fresh world state")
+    args = parser.parse_args()
+
+    print("=" * 70)
+    print("tt-agents Proof 4: Dungeon Master Agent (smolagents)")
+    print("=" * 70)
+    print(f"Model:    {args.model}")
+    print(f"Endpoint: {BASE_URL}")
+    state_src = "world.json (fresh)" if args.reset or not SESSION_FILE.exists() else "world_session.json (saved)"
+    print(f"State:    {state_src}")
+    print("\nTip: 70B gives the best narrative. Qwen3-32B is faster (~8s vs ~14s/turn).")
+    print("Commands: 'status' | 'lore' | 'quit'")
+    print("-" * 70)
+
+    _world_state = load_world(reset=args.reset)
+
+    model = OpenAIServerModel(
+        model_id=args.model,
+        api_base=BASE_URL,
+        api_key="none",
+    )
+
+    # ToolCallingAgent uses JSON tool calls (not CodeAgent's Python code generation).
+    # More predictable for interactive sessions, easier to audit turn by turn.
+    agent = ToolCallingAgent(
+        tools=[
+            get_player_status,
+            move_player,
+            pick_up_item,
+            roll_dice,
+            update_player_hp,
+            update_player_gold,
+            cast_spell,
+            examine_item,
+            manage_lore,
+            check_rules,
+        ],
+        model=model,
+        instructions=DM_SYSTEM_PROMPT,
+        max_steps=10,
+        verbosity_level=0,
+    )
+
+    print("\nThe DM is setting the scene...\n")
+    response = agent.run(
+        "Describe the starting area and greet the player. Check their status first.",
+        reset=True,
+    )
+    print(f"DM: {response}\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\n\nFarewell, adventurer!")
+            break
+
+        if not user_input:
+            continue
+
+        if user_input.lower() in ("quit", "exit", "q"):
+            print("Farewell, adventurer!")
+            break
+
+        if user_input.lower() in ("status", "stats"):
+            try:
+                s = json.loads(get_player_status())
+                slots = s.get("spell_slots", {})
+                slot_str = "  ".join(f"L{k}:{v}" for k, v in slots.items()) if slots else "none"
+                print(f"\n[Status] HP: {s['hp']} | Gold: {s['gold']} g | Location: {s['location']}")
+                print(f"[Inventory] {', '.join(s['inventory']) or 'empty'}")
+                print(f"[Spells] {', '.join(s['spellbook']) or 'none'}  |  Slots: {slot_str}")
+                print(f"[Exits] {', '.join(s['exits']) or 'none'}\n")
+            except Exception as e:
+                print(f"[Status error: {e}]\n")
+            continue
+
+        if user_input.lower() == "lore":
+            lore = _world_state.get("lore", {})
+            if lore:
+                print("\n[World Lore — recorded by the DM this session]")
+                for subject, text in lore.items():
+                    print(f"  {subject}: {text}")
+                print()
+            else:
+                print("[No lore recorded yet — explore and interact to build the world]\n")
+            continue
+
+        print("\nDM: ", end="", flush=True)
+        try:
+            response = agent.run(f"Player action: {user_input}", reset=False)
+            print(f"{response}\n")
+        except Exception as e:
+            print(f"[Error: {e}]\n")
+            continue
+
+        if _world_state["player"]["hp"] <= 0:
+            print("Your adventure ends here. Game over.")
+            break
+
+    save_world(_world_state)
+    print(f"\n[World state saved to {SESSION_FILE.name}]")
+    lore = _world_state.get("lore", {})
+    if lore:
+        print(f"[Lore entries created this session: {len(lore)}]")
+    print(f"[Turns played: {_world_state['turn']}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/content/templates/agents/04_dungeon_master.py
+++ b/content/templates/agents/04_dungeon_master.py
@@ -34,15 +34,49 @@ Install deps:
 import argparse
 import json
 import os
+import re
 import random
 import sys
 from pathlib import Path
 
 try:
     from smolagents import OpenAIServerModel, ToolCallingAgent, tool
+    from smolagents.monitoring import AgentLogger, LogLevel
+    from rich.panel import Panel
 except ImportError:
     print("ERROR: smolagents not installed. Run: pip install smolagents")
     sys.exit(1)
+
+
+class _QuietLogger(AgentLogger):
+    """Shows only tool names (not arguments or observations); suppresses the
+    spurious 'If you want to return an answer' warning."""
+
+    _MUTE = "If you want to return an answer"
+
+    def __init__(self):
+        super().__init__(level=LogLevel.INFO)
+
+    def log(self, *args, level=LogLevel.INFO, **kwargs):
+        for arg in args:
+            if isinstance(arg, Panel):
+                try:
+                    text = getattr(getattr(arg, "renderable", None), "plain", "") or ""
+                    m = re.match(r"Calling tool: '(\w+)'", text)
+                    if m and m.group(1) != "final_answer":
+                        print(f"  [{m.group(1)}]", flush=True)
+                except Exception:
+                    pass
+                return  # suppress all other Panel content (step summaries, etc.)
+        if args and isinstance(args[0], str) and "Observations:" in args[0]:
+            return
+        if int(level) <= LogLevel.ERROR:
+            self.console.print(*args, **kwargs)
+
+    def log_error(self, error_message: str) -> None:
+        if self._MUTE in error_message:
+            return
+        super().log_error(error_message)
 
 BASE_URL = os.environ.get("VLLM_BASE_URL", "http://localhost:8000/v1")
 DEFAULT_MODEL = os.environ.get("VLLM_MODEL", "meta-llama/Llama-3.3-70B-Instruct")
@@ -413,7 +447,7 @@ def main():
         model=model,
         instructions=DM_SYSTEM_PROMPT,
         max_steps=15,
-        verbosity_level=1,
+        logger=_QuietLogger(),
     )
 
     print("\nThe DM is setting the scene...\n")

--- a/content/templates/agents/requirements.txt
+++ b/content/templates/agents/requirements.txt
@@ -1,0 +1,14 @@
+# Core agent frameworks
+smolagents>=1.13.0
+openai-agents>=0.0.19
+crewai>=1.0.0
+
+# smolagents tool deps
+# Note: smolagents 1.13+ requires 'ddgs' (not 'duckduckgo-search')
+ddgs>=9.0.0
+requests>=2.32.0
+beautifulsoup4>=4.12.0
+markdownify>=0.11.0
+
+# OpenAI client (used by all frameworks for local endpoint)
+openai>=1.75.0

--- a/content/templates/agents/world.json
+++ b/content/templates/agents/world.json
@@ -1,0 +1,119 @@
+{
+  "player": {
+    "name": "Adventurer",
+    "hp": 100,
+    "max_hp": 100,
+    "gold": 10,
+    "inventory": ["torch", "short sword", "leather armor"],
+    "location": "town_square",
+    "spellbook": ["magic_missile", "healing_word", "shield"],
+    "spell_slots": {"1": 3, "2": 2}
+  },
+  "locations": {
+    "town_square": {
+      "name": "Town Square",
+      "description": "A weathered fountain marks the center of Millhaven. The water runs clear but cold, fed by a spring no one has found. Paths lead north to the Dark Forest, east to the Rusty Axe, south to the dungeon entrance, and west to the open market. The library sits in a narrow alley off the square.",
+      "exits": ["forest", "rusty_axe", "dungeon_entrance", "marketplace", "library"],
+      "npcs": ["merchant"],
+      "items": []
+    },
+    "rusty_axe": {
+      "name": "The Rusty Axe Tavern",
+      "description": "A low-ceilinged room thick with woodsmoke and the smell of barley. The barkeep is a former adventurer who lost two fingers to a trap and never went back underground.",
+      "exits": ["town_square"],
+      "npcs": ["barkeep"],
+      "items": ["healing_potion", "mysterious_coin"]
+    },
+    "marketplace": {
+      "name": "The Open Market",
+      "description": "Stalls selling spell components, monster pelts, and stranger things. A blacksmith's hammer rings from the far corner. An herbalist watches you from under a wide-brimmed hat.",
+      "exits": ["town_square"],
+      "npcs": ["blacksmith", "herbalist"],
+      "items": ["iron_shield", "health_herbs"]
+    },
+    "library": {
+      "name": "The Archivist's Library",
+      "description": "Floor-to-ceiling shelves of crumbling tomes, many in languages the archivist admits she can't read. A single lamp burns on a table covered in notes. Something scratches inside the walls.",
+      "exits": ["town_square"],
+      "npcs": ["archivist"],
+      "items": ["scroll_of_identify", "ancient_map"]
+    },
+    "forest": {
+      "name": "Dark Forest",
+      "description": "Ancient oaks block the sky within thirty feet of the treeline. The path in is clear. The path back always seems slightly different.",
+      "exits": ["town_square"],
+      "npcs": [],
+      "items": ["wolfsbane", "crow_feather"],
+      "encounter_chance": 0.4
+    },
+    "dungeon_entrance": {
+      "name": "Dungeon Entrance",
+      "description": "Crumbling stone steps lead down into darkness that doesn't smell like ordinary dark. The locals call it the Old Mouth. They don't say it fondly.",
+      "exits": ["town_square", "dungeon_level1"],
+      "npcs": [],
+      "items": ["iron_spike"]
+    },
+    "dungeon_level1": {
+      "name": "Dungeon — Level 1",
+      "description": "Damp corridors. A torch bracket holds a flame that wasn't lit when you arrived but is now. The walls are carved with runes that look almost like a language.",
+      "exits": ["dungeon_entrance", "crypt"],
+      "npcs": [],
+      "items": ["rusty_key", "torn_journal"],
+      "encounter_chance": 0.6
+    },
+    "crypt": {
+      "name": "The Old Crypt",
+      "description": "Older than the dungeon above it. The runes here glow faintly amber. The air is dry and tastes like iron. Something in the far corner is watching you, but when you look directly at it, there's nothing there.",
+      "exits": ["dungeon_level1"],
+      "npcs": ["lich_spirit"],
+      "items": ["soul_gem", "necromancer_tome"],
+      "encounter_chance": 0.8
+    }
+  },
+  "item_details": {
+    "healing_potion":    {"description": "A vial of red liquid, warm to the touch.",       "hidden": "Restores 2d8+4 HP. Brewed with ingredients from the marketplace."},
+    "mysterious_coin":   {"description": "Wrong metal, wrong weight, wrong face.",          "hidden": "The date on the back is forty years in the future."},
+    "iron_shield":       {"description": "Dented but solid round shield.",                  "hidden": "+2 AC when equipped. The dent was made by something with claws."},
+    "health_herbs":      {"description": "Dried herbs, smell of pine and copper.",          "hidden": "Heals 1d6 HP raw, or brewed into a 3d6 potion with a fire source."},
+    "scroll_of_identify":{"description": "Tightly rolled, wax seal intact.",               "hidden": "Reveals true properties of any magical item. Single use."},
+    "ancient_map":       {"description": "Hand-drawn dungeon map, rooms circled in red.",   "hidden": "Shows a level below the crypt that has no stairs on the current map."},
+    "wolfsbane":         {"description": "Sprig of wolfsbane, slightly luminescent.",       "hidden": "Repels lycanthropes. Also a component in protection rituals."},
+    "crow_feather":      {"description": "Jet black, unusually large. Still warm.",        "hidden": "Magical. Usable in divination. Came from no ordinary crow."},
+    "iron_spike":        {"description": "Foot-long iron spike, useful for wedging doors.", "hidden": "The runes on it suggest it was made to hold something specific shut."},
+    "rusty_key":         {"description": "Heavy iron key, corroded but functional.",        "hidden": "Opens more than one lock. The archivist is looking for this."},
+    "torn_journal":      {"description": "Surviving pages of dungeon notes.",               "hidden": "Last entry: 'The crypt is not a dead end. It is a door. Do not open what is inside the door.'"},
+    "soul_gem":          {"description": "Cloudy quartz the size of a fist.",              "hidden": "Something moves inside it when no one is looking. Extremely dangerous."},
+    "necromancer_tome":  {"description": "Bound in leather that is not animal.",            "hidden": "Pages are blank until you ask them a question. Currently cursed."},
+    "torch":             {"description": "Standard wooden torch. Burns for one hour.",      "hidden": "Shadows in the dungeon avoid its light more than they should."},
+    "short sword":       {"description": "Worn but well-maintained single-edged blade.",    "hidden": "1d6 damage. Has a maker's mark that matches one in the torn journal."},
+    "leather armor":     {"description": "Supple leather armor, laced at the sides.",      "hidden": "AC 11. Someone repaired the left shoulder recently, with different thread."}
+  },
+  "spells": {
+    "magic_missile": {
+      "description": "Three glowing darts streak unerringly to their target. Cannot miss.",
+      "damage": 12,
+      "slot": 1,
+      "range": "120 feet"
+    },
+    "healing_word": {
+      "description": "A word of power restores vitality in a creature you can see.",
+      "heal": 10,
+      "slot": 1,
+      "range": "60 feet"
+    },
+    "shield": {
+      "description": "An invisible barrier of force deflects incoming attacks until your next turn.",
+      "effect": "+5 AC until next turn",
+      "slot": 1,
+      "range": "self"
+    }
+  },
+  "lore": {},
+  "enemies": {
+    "goblin":   {"name": "Goblin Scout",      "hp": 20, "attack": 5,  "gold": 3, "note": "Small and fast, cowardly alone."},
+    "wolf":     {"name": "Forest Wolf",       "hp": 35, "attack": 8,  "gold": 2, "note": "Runs larger than normal. Nobody talks about why."},
+    "skeleton": {"name": "Skeleton Warrior",  "hp": 40, "attack": 10, "gold": 5, "note": "Wears armor that predates the town. Doesn't speak, but remembers."},
+    "shadow":   {"name": "Dungeon Shadow",    "hp": 28, "attack": 14, "gold": 0, "note": "Immune to nonmagical weapons. Vulnerable to light."}
+  },
+  "turn": 0
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.371",
+  "version": "0.0.400",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.370",
+  "version": "0.0.371",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",
@@ -618,6 +618,56 @@
       {
         "command": "tenstorrent.runParticleLife",
         "title": "Run Particle Life Simulation",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.startQb2AgentsServerQwen",
+        "title": "Start Qwen3-32B Agent Server",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.startQb2AgentsServerLlama",
+        "title": "Start Llama-3.3-70B Agent Server",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.checkAgentServerHealth",
+        "title": "Check Agent Server Health",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.cloneTtAgents",
+        "title": "Clone tt-agents Repository",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.copyAgentsToScratchpad",
+        "title": "Copy Agent Scripts to Scratchpad",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.runAgentsVerify",
+        "title": "Run Agent Tool Verification",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.runResearchAgent",
+        "title": "Run Research Agent (Demo 1)",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.runCodeExplorer",
+        "title": "Run Code Explorer (Demo 2)",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.runWritingPipeline",
+        "title": "Run Writing Pipeline (Demo 3)",
+        "category": "Tenstorrent"
+      },
+      {
+        "command": "tenstorrent.runDungeonMaster",
+        "title": "Run Dungeon Master (Demo 4)",
         "category": "Tenstorrent"
       }
     ]

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -694,6 +694,30 @@ ${sidebar}
   <link rel="stylesheet" href="${siteUrl('/assets/lesson-theme.css')}">
   <link rel="stylesheet" href="${siteUrl('/assets/lesson-web.css')}">
 ${head}
+${BASE_PATH ? `  <!-- PostHog analytics — only injected on production builds (SITE_BASE_PATH set). -->
+  <script>
+    (function (t, e) {
+      var o, n, p, r;
+      if (!e.__SV) {
+        window.posthog = e; e._i = []; e.init = function (i, s, a) {
+          function g(t, e) { var o = e.split("."); if (o.length === 2) { t = t[o[0]]; e = o[1]; } t[e] = function () { t.push([e].concat(Array.prototype.slice.call(arguments, 0))); }; }
+          p = t.createElement("script"); p.type = "text/javascript"; p.crossOrigin = "anonymous"; p.async = true;
+          p.src = s.api_host.replace(".i.posthog.com", "-assets.i.posthog.com") + "/static/array.js";
+          r = t.getElementsByTagName("script")[0]; r.parentNode.insertBefore(p, r);
+          var u = e; if (a !== undefined) { u = e[a] = []; } else { a = "posthog"; }
+          u.people = u.people || []; u.toString = function (t) { var e = "posthog"; if (a !== "posthog") { e += "." + a; } if (!t) { e += " (stub)"; } return e; };
+          u.people.toString = function () { return u.toString(1) + ".people (stub)"; };
+          var methods = ("init capture identify setPersonProperties reset get_distinct_id getGroups get_session_id alias set_config startSessionRecording stopSessionRecording opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug").split(" ");
+          for (n = 0; n < methods.length; n++) { g(u, methods[n]); } e._i.push([i, s, a]);
+        }; e.__SV = 1;
+      }
+    })(document, window.posthog || []);
+    posthog.init("phc_9LMRmHrCFvQNvDkPDjYBP5dZ6WchZ5bcM6T4Qj6tb0U", {
+      api_host: "https://us.i.posthog.com",
+      defaults: "2025-05-24",
+      person_profiles: "identified_only"
+    });
+  </script>` : ''}
 </head>
 <body class="${bodyClasses}">
 ${sidebarHtml}
@@ -706,12 +730,6 @@ ${content}
 
 <script src="${siteUrl('/assets/vendor/mermaid.min.js')}"></script>
 <script src="${siteUrl('/assets/lesson-web.js')}"></script>
-
-${BASE_PATH ? `<!-- PostHog analytics — only injected on production builds (SITE_BASE_PATH set). -->
-<script>
-!function(t,e){var o,n,p,r;if(!e.__SV){window.posthog=e;e._i=[];e.init=function(i,s,a){function g(t,e){var o=e.split(".");if(o.length===2){t=t[o[0]];e=o[1];}t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)));};}p=t.createElement("script");p.type="text/javascript";p.crossOrigin="anonymous";p.async=!0;p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js";r=t.getElementsByTagName("script")[0];r.parentNode.insertBefore(p,r);var u=e;if(a!==void 0){u=e[a]=[];}else{a="posthog";}u.people=u.people||[];u.toString=function(t){var e="posthog";if(a!=="posthog"){e+="."+a;}if(!t){e+=" (stub)";}return e;};u.people.toString=function(){return u.toString(1)+".people (stub)";};e._i.push([i,s,a]);};e.__SV=1;}}(document,window.posthog||[]);
-posthog.init("phc_9LMRmHrCFvQNvDkPDjYBP5dZ6WchZ5bcM6T4Qj6tb0U",{api_host:"https://us.i.posthog.com",defaults:"2025-05-24",person_profiles:"identified_only"});
-</script>` : ''}
 </body>
 </html>`;
 }

--- a/src/commands/terminalCommands.ts
+++ b/src/commands/terminalCommands.ts
@@ -739,6 +739,80 @@ export const TERMINAL_COMMANDS: Record<string, CommandTemplate> = {
     template: 'cd ~/code/tt-local-generator && ./tt-gen',
     description: 'Launches the GTK4 video generation GUI. Requires python3-gi (apt package, not venv).',
   },
+
+  // ========================================
+  // QB2 Local Agents (qb2-local-agents lesson)
+  // ========================================
+
+  START_QB2_AGENTS_SERVER_QWEN: {
+    id: 'start-qb2-agents-server-qwen',
+    name: 'Start Qwen3-32B Agent Server',
+    template: "cd ~/code/tt-inference-server && python3 run.py --model Qwen3-32B --tt-device p300x2 --workflow server --docker-server --no-auth --vllm-override-args '{\"enable_auto_tool_choice\": true, \"tool_call_parser\": \"hermes\"}'",
+    description: 'Starts vLLM with Qwen3-32B and tool calling enabled via tt-inference-server (hermes parser)',
+  },
+
+  START_QB2_AGENTS_SERVER_LLAMA: {
+    id: 'start-qb2-agents-server-llama',
+    name: 'Start Llama-3.3-70B Agent Server',
+    template: "cd ~/code/tt-inference-server && python3 run.py --model Llama-3.3-70B-Instruct --tt-device p300x2 --workflow server --docker-server --no-auth --vllm-override-args '{\"enable_auto_tool_choice\": true, \"tool_call_parser\": \"llama3_json\"}'",
+    description: 'Starts vLLM with Llama-3.3-70B-Instruct and tool calling enabled via tt-inference-server (llama3_json parser)',
+  },
+
+  CHECK_AGENT_SERVER_HEALTH: {
+    id: 'check-agent-server-health',
+    name: 'Check Agent Server Health',
+    template: 'curl -s http://localhost:8000/v1/models | python3 -m json.tool 2>/dev/null || curl http://localhost:8000/v1/models',
+    description: 'Checks the vLLM server on port 8000 and lists available models',
+  },
+
+  CLONE_TT_AGENTS: {
+    id: 'clone-tt-agents',
+    name: 'Clone tt-agents Repository',
+    template: 'git clone https://github.com/tenstorrent/tt-agents.git ~/code/tt-agents 2>/dev/null || (cd ~/code/tt-agents && git pull origin main) && cd ~/code/tt-agents && pip install --upgrade pip setuptools wheel && pip install -r requirements.txt',
+    description: 'Clones (or updates) tt-agents to ~/code/tt-agents and installs Python dependencies',
+  },
+
+  COPY_AGENTS_TO_SCRATCHPAD: {
+    id: 'copy-agents-to-scratchpad',
+    name: 'Copy Agent Scripts to Scratchpad',
+    template: 'mkdir -p ~/tt-scratchpad/agents && cp ~/code/tt-agents/*.py ~/tt-scratchpad/agents/ && cp ~/code/tt-agents/requirements.txt ~/tt-scratchpad/agents/ && cp ~/code/tt-agents/world.json ~/tt-scratchpad/agents/ && echo "✓ Agent scripts copied to ~/tt-scratchpad/agents/"',
+    description: 'Copies all agent scripts, requirements, and world.json to ~/tt-scratchpad/agents/ for safe experimentation',
+  },
+
+  RUN_AGENTS_VERIFY: {
+    id: 'run-agents-verify',
+    name: 'Run Agent Tool Verification',
+    template: 'python3 ~/code/tt-agents/00_verify_tools.py',
+    description: 'Runs the tool-calling verification script: confirms inference, tool calls, and structured output all work',
+  },
+
+  RUN_RESEARCH_AGENT: {
+    id: 'run-research-agent',
+    name: 'Run Research Agent (Demo 1)',
+    template: 'python3 ~/code/tt-agents/01_research_agent.py',
+    description: 'Runs Demo 1: smolagents CodeAgent that searches the web and synthesizes a cited report',
+  },
+
+  RUN_CODE_EXPLORER: {
+    id: 'run-code-explorer',
+    name: 'Run Code Explorer (Demo 2)',
+    template: 'python3 ~/code/tt-agents/02_code_explorer.py',
+    description: 'Runs Demo 2: OpenAI Agents SDK tool-calling agent that explores a local codebase',
+  },
+
+  RUN_WRITING_PIPELINE: {
+    id: 'run-writing-pipeline',
+    name: 'Run Writing Pipeline (Demo 3)',
+    template: 'python3 ~/code/tt-agents/03_writing_pipeline.py',
+    description: 'Runs Demo 3: CrewAI multi-agent writing pipeline (Researcher → Writer → Editor) with format picker',
+  },
+
+  RUN_DUNGEON_MASTER: {
+    id: 'run-dungeon-master',
+    name: 'Run Dungeon Master (Demo 4)',
+    template: 'python3 ~/code/tt-agents/04_dungeon_master.py',
+    description: 'Runs Demo 4: smolagents ToolCallingAgent persistent-world dungeon master with generative tools',
+  },
 };
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -866,7 +866,7 @@ async function createChatScript(): Promise<void> {
 
   // Get the template path from the extension
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-chat.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-chat.py');
 
   // Check if template exists
   if (!fs.existsSync(templatePath)) {
@@ -954,7 +954,7 @@ async function createApiServer(): Promise<void> {
 
   // Get the template path from the extension
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-api-server.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-api-server.py');
 
   // Check if template exists
   if (!fs.existsSync(templatePath)) {
@@ -1096,7 +1096,7 @@ async function createChatScriptDirect(): Promise<void> {
   const os = await import('os');
 
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-chat-direct.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-chat-direct.py');
 
   if (!fs.existsSync(templatePath)) {
     vscode.window.showErrorMessage(
@@ -1172,7 +1172,7 @@ async function createApiServerDirect(): Promise<void> {
   const os = await import('os');
 
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-api-server-direct.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-api-server-direct.py');
 
   if (!fs.existsSync(templatePath)) {
     vscode.window.showErrorMessage(
@@ -1489,7 +1489,7 @@ async function startVllmServer(): Promise<void> {
 
   if (!fs.existsSync(starterPath)) {
     const extensionPath = extensionContext.extensionPath;
-    const templatePath = path.join(extensionPath, 'content', 'templates', 'start-vllm-server.py');
+    const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'start-vllm-server.py');
 
     if (fs.existsSync(templatePath)) {
       fs.copyFileSync(templatePath, starterPath);
@@ -1603,7 +1603,7 @@ async function startVllmServerForHardware(
 
   if (!fs.existsSync(starterPath)) {
     const extensionPath = extensionContext.extensionPath;
-    const templatePath = path.join(extensionPath, 'content', 'templates', 'start-vllm-server.py');
+    const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'start-vllm-server.py');
 
     if (fs.existsSync(templatePath)) {
       fs.copyFileSync(templatePath, starterPath);
@@ -1731,7 +1731,7 @@ async function createVllmStarter(): Promise<void> {
 
   // Copy template
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'start-vllm-server.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'start-vllm-server.py');
 
   if (!fs.existsSync(templatePath)) {
     vscode.window.showErrorMessage('❌ Template not found: start-vllm-server.py');
@@ -1774,7 +1774,7 @@ async function installAllScripts(): Promise<void> {
   }
 
   const extensionPath = extensionContext.extensionPath;
-  const templatesDir = path.join(extensionPath, 'content', 'templates');
+  const templatesDir = path.join(extensionPath, 'dist', 'content', 'templates');
 
   // List of scripts to install (the ones referenced in lessons)
   const scriptsToInstall = [
@@ -2206,7 +2206,7 @@ async function createCodingAssistantScript(): Promise<void> {
   const os = await import('os');
 
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-coding-assistant.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-coding-assistant.py');
 
   if (!fs.existsSync(templatePath)) {
     vscode.window.showErrorMessage(
@@ -2322,7 +2322,7 @@ async function createForgeClassifier(): Promise<void> {
   const os = await import('os');
 
   const extensionPath = extensionContext.extensionPath;
-  const templatePath = path.join(extensionPath, 'content', 'templates', 'tt-forge-classifier.py');
+  const templatePath = path.join(extensionPath, 'dist', 'content', 'templates', 'tt-forge-classifier.py');
 
   if (!fs.existsSync(templatePath)) {
     vscode.window.showErrorMessage(
@@ -2800,14 +2800,20 @@ async function showWelcome(context: vscode.ExtensionContext): Promise<void> {
     { viewColumn: vscode.ViewColumn.One, preserveFocus: false },
     {
       enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'content', 'pages')]
+      localResourceRoots: [
+        vscode.Uri.joinPath(context.extensionUri, 'dist', 'content', 'pages'),
+        vscode.Uri.joinPath(context.extensionUri, 'content', 'pages')
+      ]
     }
   );
 
   // Load welcome HTML
   const fs = await import('fs');
   const path = await import('path');
-  const welcomePath = path.join(context.extensionPath, 'content', 'pages', 'welcome.html');
+  const pagesBase = fs.existsSync(path.join(context.extensionPath, 'dist', 'content', 'pages'))
+    ? path.join(context.extensionPath, 'dist', 'content', 'pages')
+    : path.join(context.extensionPath, 'content', 'pages');
+  const welcomePath = path.join(pagesBase, 'welcome.html');
 
   if (fs.existsSync(welcomePath)) {
     panel.webview.html = fs.readFileSync(welcomePath, 'utf8');
@@ -2848,6 +2854,7 @@ async function showFaq(context: vscode.ExtensionContext): Promise<void> {
     {
       enableScripts: true,
       localResourceRoots: [
+        vscode.Uri.joinPath(context.extensionUri, 'dist', 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'dist', 'src', 'webview')
       ]
@@ -2858,15 +2865,19 @@ async function showFaq(context: vscode.ExtensionContext): Promise<void> {
   const path = await import('path');
 
   try {
+    const pagesBase = fs.existsSync(path.join(context.extensionPath, 'dist', 'content', 'pages'))
+      ? path.join(context.extensionPath, 'dist', 'content', 'pages')
+      : path.join(context.extensionPath, 'content', 'pages');
+
     // Read FAQ markdown
-    const faqPath = path.join(context.extensionPath, 'content', 'pages', 'FAQ.md');
+    const faqPath = path.join(pagesBase, 'FAQ.md');
 
     // Use MarkdownRenderer for consistency
     const renderer = new MarkdownRenderer();
     const rendered = await renderer.renderFile(faqPath);
 
     // Read template
-    const templatePath = path.join(context.extensionPath, 'content', 'pages', 'faq-template.html');
+    const templatePath = path.join(pagesBase, 'faq-template.html');
     let template = fs.readFileSync(templatePath, 'utf8');
 
     // Update CSP to allow CDN resources
@@ -2912,6 +2923,7 @@ async function showRiscvGuide(context: vscode.ExtensionContext): Promise<void> {
     {
       enableScripts: true,
       localResourceRoots: [
+        vscode.Uri.joinPath(context.extensionUri, 'dist', 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'dist', 'src', 'webview')
       ]
@@ -2922,15 +2934,19 @@ async function showRiscvGuide(context: vscode.ExtensionContext): Promise<void> {
   const path = await import('path');
 
   try {
+    const pagesBase = fs.existsSync(path.join(context.extensionPath, 'dist', 'content', 'pages'))
+      ? path.join(context.extensionPath, 'dist', 'content', 'pages')
+      : path.join(context.extensionPath, 'content', 'pages');
+
     // Read RISC-V guide markdown
-    const guidePath = path.join(context.extensionPath, 'content', 'pages', 'riscv-guide.md');
+    const guidePath = path.join(pagesBase, 'riscv-guide.md');
 
     // Use MarkdownRenderer for consistency
     const renderer = new MarkdownRenderer();
     const rendered = await renderer.renderFile(guidePath);
 
     // Read template
-    const templatePath = path.join(context.extensionPath, 'content', 'pages', 'faq-template.html');
+    const templatePath = path.join(pagesBase, 'faq-template.html');
     let template = fs.readFileSync(templatePath, 'utf8');
 
     // Update CSP to allow CDN resources
@@ -2977,6 +2993,7 @@ async function showStepZero(context: vscode.ExtensionContext): Promise<void> {
     {
       enableScripts: true,
       localResourceRoots: [
+        vscode.Uri.joinPath(context.extensionUri, 'dist', 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'content', 'pages'),
         vscode.Uri.joinPath(context.extensionUri, 'dist', 'src', 'webview')
       ]
@@ -2987,15 +3004,19 @@ async function showStepZero(context: vscode.ExtensionContext): Promise<void> {
   const path = await import('path');
 
   try {
+    const pagesBase = fs.existsSync(path.join(context.extensionPath, 'dist', 'content', 'pages'))
+      ? path.join(context.extensionPath, 'dist', 'content', 'pages')
+      : path.join(context.extensionPath, 'content', 'pages');
+
     // Read Step Zero markdown
-    const stepZeroPath = path.join(context.extensionPath, 'content', 'pages', 'step-zero.md');
+    const stepZeroPath = path.join(pagesBase, 'step-zero.md');
 
     // Use MarkdownRenderer for proper mermaid support
     const renderer = new MarkdownRenderer();
     const rendered = await renderer.renderFile(stepZeroPath);
 
     // Read template
-    const templatePath = path.join(context.extensionPath, 'content', 'pages', 'faq-template.html');
+    const templatePath = path.join(pagesBase, 'faq-template.html');
     let template = fs.readFileSync(templatePath, 'utf8');
 
     // Inject mermaid.js script tags before closing </body>
@@ -4352,7 +4373,7 @@ class TenstorrentImagePreviewProvider implements vscode.WebviewViewProvider {
     webviewView.webview.options = {
       enableScripts: true,
       localResourceRoots: [
-        vscode.Uri.joinPath(this.context.extensionUri, 'assets'),
+        vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'assets'),
         vscode.Uri.file(require('os').homedir())
       ]
     };
@@ -4428,7 +4449,7 @@ class TenstorrentImagePreviewProvider implements vscode.WebviewViewProvider {
     } else {
       // Show default logo with telemetry animation
       imageUri = webview.asWebviewUri(
-        vscode.Uri.joinPath(this.context.extensionUri, 'assets', 'img', 'tt_logo_color_dark_backgrounds.svg')
+        vscode.Uri.joinPath(this.context.extensionUri, 'dist', 'assets', 'img', 'tt_logo_color_dark_backgrounds.svg')
       );
       altText = 'Tenstorrent';
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4110,6 +4110,130 @@ function launchTtGen(): void {
 }
 
 // ============================================================================
+// QB2 Local Agents (qb2-local-agents lesson)
+// ============================================================================
+
+/**
+ * Command: tenstorrent.startQb2AgentsServerQwen
+ * Starts vLLM with Qwen3-32B and hermes tool-call parser.
+ */
+function startQb2AgentsServerQwen(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.START_QB2_AGENTS_SERVER_QWEN.template);
+  vscode.window.showInformationMessage(
+    'Starting Qwen3-32B agent server. Warmup takes ~5 min (up to 20 min on first run).'
+  );
+}
+
+/**
+ * Command: tenstorrent.startQb2AgentsServerLlama
+ * Starts vLLM with Llama-3.3-70B-Instruct and llama3_json tool-call parser.
+ */
+function startQb2AgentsServerLlama(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.START_QB2_AGENTS_SERVER_LLAMA.template);
+  vscode.window.showInformationMessage(
+    'Starting Llama-3.3-70B-Instruct agent server. Warmup takes ~5 min (up to 20 min on first run).'
+  );
+}
+
+/**
+ * Command: tenstorrent.checkAgentServerHealth
+ * Lists available models from the vLLM server on port 8000.
+ */
+function checkAgentServerHealth(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.CHECK_AGENT_SERVER_HEALTH.template);
+  vscode.window.showInformationMessage(
+    'Checking agent server health. Look for your model in the response.'
+  );
+}
+
+/**
+ * Command: tenstorrent.cloneTtAgents
+ * Clones tt-agents and installs Python dependencies.
+ */
+function cloneTtAgents(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.CLONE_TT_AGENTS.template);
+  vscode.window.showInformationMessage(
+    'Cloning tt-agents and installing dependencies. Check the terminal for progress.'
+  );
+}
+
+/**
+ * Command: tenstorrent.copyAgentsToScratchpad
+ * Copies agent scripts and world.json to ~/tt-scratchpad/agents/.
+ */
+function copyAgentsToScratchpad(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.COPY_AGENTS_TO_SCRATCHPAD.template);
+  vscode.window.showInformationMessage(
+    'Agent scripts copied to ~/tt-scratchpad/agents/ — hack away without touching the originals.'
+  );
+}
+
+/**
+ * Command: tenstorrent.runAgentsVerify
+ * Runs the 00_verify_tools.py pre-flight check.
+ */
+function runAgentsVerify(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.RUN_AGENTS_VERIFY.template);
+  vscode.window.showInformationMessage(
+    'Running agent verification. All three checks (inference, tool_call, structured) should pass.'
+  );
+}
+
+/**
+ * Command: tenstorrent.runResearchAgent
+ * Runs Demo 1: smolagents CodeAgent web research pipeline.
+ */
+function runResearchAgent(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.RUN_RESEARCH_AGENT.template);
+  vscode.window.showInformationMessage(
+    'Starting research agent. Pick a topic or press Enter to accept today\'s suggestion.'
+  );
+}
+
+/**
+ * Command: tenstorrent.runCodeExplorer
+ * Runs Demo 2: OpenAI Agents SDK codebase explorer.
+ */
+function runCodeExplorer(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.RUN_CODE_EXPLORER.template);
+  vscode.window.showInformationMessage(
+    'Starting code explorer. Ask questions about any local codebase.'
+  );
+}
+
+/**
+ * Command: tenstorrent.runWritingPipeline
+ * Runs Demo 3: CrewAI multi-agent writing pipeline.
+ */
+function runWritingPipeline(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.RUN_WRITING_PIPELINE.template);
+  vscode.window.showInformationMessage(
+    'Starting writing pipeline. Choose a format or press Enter for today\'s rotation.'
+  );
+}
+
+/**
+ * Command: tenstorrent.runDungeonMaster
+ * Runs Demo 4: smolagents persistent-world dungeon master.
+ */
+function runDungeonMaster(): void {
+  const terminal = getOrCreateSimpleTerminal();
+  runInTerminal(terminal, TERMINAL_COMMANDS.RUN_DUNGEON_MASTER.template);
+  vscode.window.showInformationMessage(
+    'Starting dungeon master. State persists in world_session.json between sessions.'
+  );
+}
+
+// ============================================================================
 // Command Menu
 // ============================================================================
 
@@ -4811,6 +4935,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('tenstorrent.startPromptGenServer', startPromptGenServer),
     vscode.commands.registerCommand('tenstorrent.checkVideoServerHealth', checkVideoServerHealth),
     vscode.commands.registerCommand('tenstorrent.launchTtGen', launchTtGen),
+
+    // QB2 Local Agents (qb2-local-agents lesson)
+    vscode.commands.registerCommand('tenstorrent.startQb2AgentsServerQwen', startQb2AgentsServerQwen),
+    vscode.commands.registerCommand('tenstorrent.startQb2AgentsServerLlama', startQb2AgentsServerLlama),
+    vscode.commands.registerCommand('tenstorrent.checkAgentServerHealth', checkAgentServerHealth),
+    vscode.commands.registerCommand('tenstorrent.cloneTtAgents', cloneTtAgents),
+    vscode.commands.registerCommand('tenstorrent.copyAgentsToScratchpad', copyAgentsToScratchpad),
+    vscode.commands.registerCommand('tenstorrent.runAgentsVerify', runAgentsVerify),
+    vscode.commands.registerCommand('tenstorrent.runResearchAgent', runResearchAgent),
+    vscode.commands.registerCommand('tenstorrent.runCodeExplorer', runCodeExplorer),
+    vscode.commands.registerCommand('tenstorrent.runWritingPipeline', runWritingPipeline),
+    vscode.commands.registerCommand('tenstorrent.runDungeonMaster', runDungeonMaster),
 
     // Bounty Program
     vscode.commands.registerCommand('tenstorrent.browseOpenBounties', browseOpenBounties),

--- a/src/utils/LessonRegistry.ts
+++ b/src/utils/LessonRegistry.ts
@@ -34,11 +34,11 @@ export class LessonRegistry {
    */
   async load(): Promise<void> {
     try {
-      const registryPath = path.join(
-        this.extensionContext.extensionPath,
-        'content',
-        'lesson-registry.json'
-      );
+      // Try dist/content/ first (packaged extension), fall back to content/ (dev mode without copy-content)
+      let registryPath = path.join(this.extensionContext.extensionPath, 'dist', 'content', 'lesson-registry.json');
+      if (!fs.existsSync(registryPath)) {
+        registryPath = path.join(this.extensionContext.extensionPath, 'content', 'lesson-registry.json');
+      }
 
       if (!fs.existsSync(registryPath)) {
         throw new Error(`Lesson registry not found at: ${registryPath}`);

--- a/src/views/LessonWebviewManager.ts
+++ b/src/views/LessonWebviewManager.ts
@@ -11,6 +11,7 @@
  */
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import * as path from 'path';
 import { LessonRegistry } from '../utils';
 import { ProgressTracker } from '../state';
@@ -145,11 +146,11 @@ export class LessonWebviewManager {
         transformImageUrl: (url: string) => this.transformImageUrl(url)
       });
 
-      // Render markdown
-      const contentPath = path.join(
-        this.context.extensionPath,
-        lesson.markdownFile
-      );
+      // Render markdown — try dist/ prefix first (packaged ext), fall back to source tree (dev mode)
+      let contentPath = path.join(this.context.extensionPath, 'dist', lesson.markdownFile);
+      if (!fs.existsSync(contentPath)) {
+        contentPath = path.join(this.context.extensionPath, lesson.markdownFile);
+      }
       const rendered = await renderer.renderFile(contentPath);
 
       // Get webview URIs

--- a/src/webview/styles/lesson-theme.css
+++ b/src/webview/styles/lesson-theme.css
@@ -177,12 +177,23 @@ pre {
   padding: 16px;
   overflow-x: auto;
   margin: 16px 0;
+  /* Explicit whitespace control — VSCode webview can override user-agent pre styles */
+  white-space: pre;
+  word-break: normal;
+  overflow-wrap: normal;
+  font-family: var(--vscode-editor-font-family, monospace);
+  font-size: var(--vscode-font-size);
+  line-height: 1.5;
 }
 
 pre code {
   background: transparent;
   padding: 0;
   border: none;
+  /* Inherit pre's whitespace settings rather than code's inline defaults */
+  white-space: inherit;
+  font-size: inherit;
+  line-height: inherit;
 }
 
 /* Inline code */

--- a/test/lesson-tests/templates.test.ts
+++ b/test/lesson-tests/templates.test.ts
@@ -18,14 +18,26 @@ import * as path from 'path';
 
 const execAsync = promisify(exec);
 
+async function collectPyFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...await collectPyFiles(full));
+    } else if (entry.name.endsWith('.py')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
 describe('Python Template Validation', () => {
   const templatesDir = path.join(__dirname, '../../content/templates');
   let pythonTemplates: string[] = [];
 
   before(async () => {
-    // Discover all Python templates
-    const allFiles = await fs.readdir(templatesDir);
-    pythonTemplates = allFiles.filter(f => f.endsWith('.py'));
+    pythonTemplates = await collectPyFiles(templatesDir);
 
     expect(pythonTemplates.length).to.be.greaterThan(
       0,
@@ -37,15 +49,14 @@ describe('Python Template Validation', () => {
     it('all Python templates should have valid syntax', async function() {
       this.timeout(10000); // Syntax checking can take a moment
 
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
-
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
         try {
           // Compile to check syntax (doesn't execute)
           await execAsync(`python3 -m py_compile "${filePath}"`);
         } catch (error) {
           throw new Error(
-            `${template} has invalid Python syntax: ${error instanceof Error ? error.message : 'Unknown error'}`
+            `${name} has invalid Python syntax: ${error instanceof Error ? error.message : 'Unknown error'}`
           );
         }
       }
@@ -54,19 +65,19 @@ describe('Python Template Validation', () => {
 
   describe('File Structure', () => {
     it('all templates should be non-empty', async () => {
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
         const content = await fs.readFile(filePath, 'utf-8');
         expect(content.length).to.be.greaterThan(
           100,
-          `${template} is too short (likely empty or incomplete)`
+          `${name} is too short (likely empty or incomplete)`
         );
       }
     });
 
     it('all templates should have documentation', async () => {
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
         const content = await fs.readFile(filePath, 'utf-8');
 
         // Should have either a docstring or comment
@@ -75,19 +86,19 @@ describe('Python Template Validation', () => {
           content.includes("'''") ||
           content.includes('#');
 
-        expect(hasDocumentation, `${template} should have documentation (comments or docstrings)`).to.equal(true);
+        expect(hasDocumentation, `${name} should have documentation (comments or docstrings)`).to.equal(true);
       }
     });
 
     it('all templates should have proper file encoding', async () => {
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
 
         // Should be able to read as UTF-8 without errors
         try {
           await fs.readFile(filePath, 'utf-8');
         } catch (error) {
-          throw new Error(`${template} has invalid UTF-8 encoding`);
+          throw new Error(`${name} has invalid UTF-8 encoding`);
         }
       }
     });
@@ -95,19 +106,20 @@ describe('Python Template Validation', () => {
 
   describe('Python 3 Compatibility', () => {
     it('templates should use Python 3 print function', async () => {
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
         const content = await fs.readFile(filePath, 'utf-8');
 
-        // Check for Python 2 print statements (should not exist)
-        const hasPython2Print = /print\s+[^(]/.test(content);
-        expect(hasPython2Print, `${template} uses Python 2 print syntax`).to.equal(false);
+        // Check for Python 2 print statements (anchored to start of line to
+        // avoid false positives from the word "print" inside comments/docstrings)
+        const hasPython2Print = content.split('\n').some(line => /^\s*print\s+[^(]/.test(line));
+        expect(hasPython2Print, `${name} uses Python 2 print syntax`).to.equal(false);
       }
     });
 
     it('templates should not use Python 2 string formatting', async () => {
-      for (const template of pythonTemplates) {
-        const filePath = path.join(templatesDir, template);
+      for (const filePath of pythonTemplates) {
+        const name = path.relative(templatesDir, filePath);
         const content = await fs.readFile(filePath, 'utf-8');
 
         // Check for old-style string formatting (should avoid)
@@ -123,7 +135,7 @@ describe('Python Template Validation', () => {
 
         // This is a warning, not a hard failure
         if (hasOldStringFormat) {
-          console.warn(`  ⚠ ${template} uses old-style % string formatting (consider f-strings)`);
+          console.warn(`  ⚠ ${name} uses old-style % string formatting (consider f-strings)`);
         }
       }
     });
@@ -136,7 +148,8 @@ describe('Python Template Validation', () => {
         'Should discover at least one Python template'
       );
 
-      console.log(`  ✓ Found ${pythonTemplates.length} Python template(s): ${pythonTemplates.join(', ')}`);
+      const names = pythonTemplates.map(f => path.relative(templatesDir, f));
+      console.log(`  ✓ Found ${pythonTemplates.length} Python template(s): ${names.join(', ')}`);
     });
 
     it('templates directory should be accessible', async () => {


### PR DESCRIPTION
This pull request introduces several improvements and additions related to local AI agent support, content organization, and packaging for the extension. The most notable changes are the addition of a new lesson and template for local agent demos, improved handling of asset packaging, and minor content and formatting corrections.

**Local AI agents and agent demo support:**

* Added a new lesson, `"Local AI Agents on QuietBox 2"`, to `content/lesson-registry.json`, covering building and validating local agent pipelines with tool calling and multi-agent support on QB2 hardware. This includes all metadata, tags, and validation notes.
* Added a new template script, `content/templates/agents/00_verify_tools.py`, which verifies tool calling and structured output support against a local vLLM endpoint. This script checks basic inference, function/tool calling, and JSON output to ensure agent demos will work.

**Asset packaging improvements:**

* Updated `.vscodeignore` and the changelog to ensure the `assets/` directory is not packaged twice in the `.vsix` extension bundle. Now only `dist/assets/` is shipped, preventing duplication and reducing package size. [[1]](diffhunk://#diff-0a721cd4753ff50bbbe1237397c3c7692080254fa766268fcc8b05ef633c50bfL72-R80) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R16)

**Content and formatting corrections:**

* Standardized emoji and special character encoding in `content/lesson-registry.json` for improved compatibility and consistency.
* Fixed several instances of em dash and superscript usage in lesson descriptions for proper Unicode representation. [[1]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L142-R142) [[2]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L173-R173) [[3]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L270-R270) [[4]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L404-R404) [[5]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L851-R851) [[6]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L883-R883) [[7]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L917-R917) [[8]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L1154-R1154) [[9]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L1209-R1209) [[10]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L1367-R1367) [[11]](diffhunk://#diff-363e98e9f349d76bd5b67fc27275af7fc0ed23c29ee71c95f417076c39f46469L1389-R1420)