### PR TITLE
fix(webview): YouTube fallback, external links, image path fix, QB2 agents lesson updates (v0.0.419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.418] - 2026-04-29
+
+### Fixed
+
+- **`scripts/build-web.js` image path rewriting** — added `WEB_RENDERER.image` handler to rewrite absolute image `src` paths through `siteUrl()` so they resolve correctly on GitHub Pages when `SITE_BASE_PATH=/tt-vscode-toolkit` is set; previously, markdown images with `/assets/img/...` paths resolved to the domain root (`https://docs.tenstorrent.com/assets/img/...`) rather than the sub-path the site lives under (`https://docs.tenstorrent.com/tt-vscode-toolkit/assets/img/...`), causing all lesson images to 404 on the live site
+
+---
+
 ## [0.0.417] - 2026-04-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`src/renderers/MarkdownRenderer.ts` YouTube replacement ordering** — moved YouTube iframe→thumbnail replacement to *before* the `sanitizeHtml` call so the generated `<a>` and `<img>` markup is covered by the sanitizer; added `style` to `allowedAttributes` for `a` and `img` to preserve the thumbnail layout styles after sanitization
 - **`content/templates/agents/06_landscape_svg.py` `_glitch_sun_bleed` regex** — broadened circle-matching regex to accept paired close tags (`</circle>`), single-quoted radius values, and decimal/float radii so the sun-bleed glitch effect fires reliably on LLM-generated SVG
 - **`content/templates/agents/02_code_explorer.py` context-limit message** — removed stray `]` from the end of the context-limit help string that was leaking into user-visible output
+- **`src/webview/scripts/lesson-viewer.js` click handler** — guarded `event.target.closest()` with an `instanceof Element` check to prevent TypeError when the click target is a Text node or other non-Element
 
 ---
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`src/renderers/MarkdownRenderer.ts` YouTube thumbnail fallback** — replaced YouTube `<iframe>` embeds with a static thumbnail + external link to avoid VSCode Error 153 (CSP blocks iframes from external origins in webviews); clicking the thumbnail opens the video in the system browser
 - **`src/views/LessonWebviewManager.ts` `openExternal` message handler** — added handler so external links (`<a target="_blank">`) clicked inside the lesson webview open in the OS browser rather than inside the webview
-- **`media/lesson-viewer.js` external link intercept** — added click listener that posts `openExternal` messages for links pointing outside the webview origin
+- **`src/webview/scripts/lesson-viewer.js` external link intercept** — added click listener that posts `openExternal` messages for links pointing outside the webview origin
 - **`content/lessons/qb2-local-agents.md` updates** — expanded QB2 agents lesson with YouTube embed section, glitch-art lesson section, and landscape SVG template sync
 - **`content/templates/agents/06_landscape_svg.py` glitch post-processing** — added additional scene generation and glitch effects to the landscape SVG template
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.0.418] - 2026-04-29
+## [0.0.420] - 2026-04-29
+
+### Fixed
+
+- **`src/views/LessonWebviewManager.ts` `openExternal` scheme validation** — restricted `openExternal` handler to only open `http`/`https` URIs; other schemes (file:, vscode:, command:, etc.) are now silently ignored to prevent webview messages from opening unintended URIs
+- **`src/renderers/MarkdownRenderer.ts` YouTube replacement ordering** — moved YouTube iframe→thumbnail replacement to *before* the `sanitizeHtml` call so the generated `<a>` and `<img>` markup is covered by the sanitizer; added `style` to `allowedAttributes` for `a` and `img` to preserve the thumbnail layout styles after sanitization
+- **`content/templates/agents/06_landscape_svg.py` `_glitch_sun_bleed` regex** — broadened circle-matching regex to accept paired close tags (`</circle>`), single-quoted radius values, and decimal/float radii so the sun-bleed glitch effect fires reliably on LLM-generated SVG
+- **`content/templates/agents/02_code_explorer.py` context-limit message** — removed stray `]` from the end of the context-limit help string that was leaking into user-visible output
+
+---
+
+## [0.0.419] - 2026-04-29
+
+### Added
+
+- **`src/renderers/MarkdownRenderer.ts` YouTube thumbnail fallback** — replaced YouTube `<iframe>` embeds with a static thumbnail + external link to avoid VSCode Error 153 (CSP blocks iframes from external origins in webviews); clicking the thumbnail opens the video in the system browser
+- **`src/views/LessonWebviewManager.ts` `openExternal` message handler** — added handler so external links (`<a target="_blank">`) clicked inside the lesson webview open in the OS browser rather than inside the webview
+- **`media/lesson-viewer.js` external link intercept** — added click listener that posts `openExternal` messages for links pointing outside the webview origin
+- **`content/lessons/qb2-local-agents.md` updates** — expanded QB2 agents lesson with YouTube embed section, glitch-art lesson section, and landscape SVG template sync
+- **`content/templates/agents/06_landscape_svg.py` glitch post-processing** — added additional scene generation and glitch effects to the landscape SVG template
 
 ### Fixed
 

--- a/content/lessons/qb2-local-agents.md
+++ b/content/lessons/qb2-local-agents.md
@@ -32,6 +32,10 @@ The interesting part is that you now have the hardware to run **AI agents that a
 
 This lesson is the raw-Python antidote to the OpenClaw lesson. No frameworks to configure, no services to restart, no JSON files to edit. Seven scripts. `pip install`. `python3 run.py`. You see every tool call, every step, every decision the model makes.
 
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;border-radius:6px;margin:24px 0;">
+  <iframe src="https://www.youtube-nocookie.com/embed/WcTe_TejcVs" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen title="Local AI Agents on QuietBox 2"></iframe>
+</div>
+
 ---
 
 ## What You'll Build
@@ -1159,7 +1163,65 @@ Sample output (default `sunset` palette):
 
 **Why no framework?** The task doesn't need agents, tools, or multi-step reasoning. It's a single structured generation: prompt in, SVG out. Reaching for CrewAI or smolagents here would add complexity with no benefit. This demo exists to show the contrast — knowing when to use a framework is as important as knowing how.
 
-**The key prompt technique:** Instead of asking the model to "draw a landscape," the prompt specifies every layer explicitly — which gradient IDs to define in `<defs>`, which colors to use for each mountain ridge, that polygon points must span `0,450` to `800,450` to close at the bottom edge. The LLM's job is to fill in the actual shape coordinates, not to make architectural decisions.
+### Smarter Layering Rules
+
+The key prompt technique is specifying every layer explicitly — gradient IDs, color assignments, polygon closing rules — so the LLM fills in coordinates, not architecture. But **ordering matters as much as content**.
+
+SVG renders elements in document order: elements written later appear visually on top. If the sun circle appears after the mountain polygons, the sun floats over the mountains instead of peeking behind them. The prompt encodes this as a rule the LLM cannot miss:
+
+```
+LAYERS (back to front):
+  1. Sky gradient
+  2. Atmospheric glow
+  3. Sun or moon  ← rendered here, BEFORE mountains
+  4. Clouds
+  5. Far mountains
+  6. Mid mountains
+  7. Near mountains  ← peaks visually occlude the sun
+  8. Ground
+
+RULES:
+  - Sun/moon MUST be drawn before mountain polygons so peaks occlude it
+  - Mountain polygons must close at canvas bottom (y=450) — no floating ridges
+```
+
+A few other rules the prompt enforces that beginners skip and then wonder why the output looks wrong:
+
+- **Mountains anchor to y=450** — each polygon's points string starts `0,450` and ends `800,450`, closing along the bottom edge. Without this, you get floating ridge silhouettes with a gap below them.
+- **Palette-only colors** — no invented hex values. The LLM is creative but consistent only when its color choices are bounded.
+- **No `<text>` or `<image>`** — models sometimes hallucinate labels or external image refs that break the SVG.
+
+### Glitchify
+
+Once you have a valid SVG, you can post-process it in Python without touching the model again. The `--glitch` flag applies four effects to produce `landscape_glitch.svg` alongside the clean version:
+
+```bash
+# Generate clean + glitched in one run
+python3 ~/code/tt-agents/06_landscape_svg.py --glitch
+
+# Same glitch output every run (reproducible with seed)
+python3 ~/code/tt-agents/06_landscape_svg.py --glitch --glitch-seed 42
+```
+
+**What each effect does:**
+
+```
+corrupt    Replace ~half the hex colors with wrong saturated values
+           (#FF00FF, #00FFFF, #FFFF00...) — mountains turn magenta, sky turns cyan
+
+sun-bleed  Move the sun/moon circle to the last SVG element so it renders on top of
+           all mountain layers — the rule we enforced in the prompt, intentionally broken
+
+flip       Wrap all content in scale(1,-1) translate(0,-450) — sky becomes ground,
+           ground becomes sky, mountains hang upside-down from the top of the frame
+
+ghost      Inject 6-11 semi-transparent <text> elements with garbled box-drawing
+           characters scattered across the scene at random positions and colors
+```
+
+All four run in sequence on every `--glitch` call. The effects stack — corrupt colors then flip then ghost text gives a different result than any single effect alone.
+
+The teaching point: **SVG is XML text, not a black box.** You can slice it with regex, reorder elements, wrap content in transforms, and inject new elements entirely in Python — no second model call, no new dependencies. The LLM generates the structure; you control the mutations.
 
 ---
 

--- a/content/templates/agents/02_code_explorer.py
+++ b/content/templates/agents/02_code_explorer.py
@@ -144,7 +144,7 @@ async def run_query(agent: Agent, query: str) -> str:
                 "Tips:\n"
                 "  • Use --query with a narrower question (one file, one function, one concept)\n"
                 "  • Use --dir pointing at a subdirectory rather than the whole project\n"
-                "  • Ask about specific files directly: --query 'explain src/auth/login.py'\n]"
+                "  • Ask about specific files directly: --query 'explain src/auth/login.py'\n"
             )
         raise
 

--- a/content/templates/agents/02_code_explorer.py
+++ b/content/templates/agents/02_code_explorer.py
@@ -144,7 +144,7 @@ async def run_query(agent: Agent, query: str) -> str:
                 "Tips:\n"
                 "  • Use --query with a narrower question (one file, one function, one concept)\n"
                 "  • Use --dir pointing at a subdirectory rather than the whole project\n"
-                "  • Ask about specific files directly: --query 'explain src/auth/login.py'\n"
+                "  • Ask about specific files directly: --query 'explain src/auth/login.py'\n]"
             )
         raise
 

--- a/content/templates/agents/06_landscape_svg.py
+++ b/content/templates/agents/06_landscape_svg.py
@@ -265,10 +265,15 @@ def _glitch_corrupt_colors(svg: str, rng: _random.Random) -> tuple[str, str]:
 
 def _glitch_sun_bleed(svg: str) -> tuple[str, str]:
     """Move the largest circle (sun/moon) to the final element — renders over mountains."""
-    pat = re.compile(r'<circle\b[^>]*r="(\d+)"[^>]*/>', re.DOTALL)
-    best_match, best_r = None, 0
+    # Match self-closing (<circle ... />) and paired (<circle ...></circle>) forms.
+    # Accept single or double quotes and integer or decimal radii.
+    pat = re.compile(
+        r'<circle\b[^>]*\br=["\'](\d+(?:\.\d+)?)["\'][^>]*(?:/>|>\s*</circle>)',
+        re.DOTALL,
+    )
+    best_match, best_r = None, 0.0
     for m in pat.finditer(svg):
-        r = int(m.group(1))
+        r = float(m.group(1))
         if r > best_r:
             best_r, best_match = r, m
     if best_match is None or best_r < 20:
@@ -276,7 +281,7 @@ def _glitch_sun_bleed(svg: str) -> tuple[str, str]:
     el = best_match.group(0)
     svg = svg[: best_match.start()] + svg[best_match.end():]
     svg = svg.replace("</svg>", f"  {el}\n</svg>")
-    return svg, f"sun-bleed: sun (r={best_r}) moved above all mountains"
+    return svg, f"sun-bleed: sun (r={best_r:.0f}) moved above all mountains"
 
 
 def _glitch_flip(svg: str) -> tuple[str, str]:

--- a/content/templates/agents/06_landscape_svg.py
+++ b/content/templates/agents/06_landscape_svg.py
@@ -10,6 +10,7 @@ Demonstrates:
   - LLM writes proper SVG with <defs> gradients, layered <polygon> terrain,
     cloud ellipse groups, atmospheric effects — full SVG primitive generation
   - Parse + validate LLM SVG output before saving
+  - Post-process generated SVG without a second LLM call (--glitch)
 
 Usage:
   python3 06_landscape_svg.py                              (sunset palette, mountains)
@@ -17,6 +18,7 @@ Usage:
   python3 06_landscape_svg.py --palette purple --mountains --clouds --stars
   python3 06_landscape_svg.py --palette red --clouds
   python3 06_landscape_svg.py --simulate                   (print prompt, skip LLM)
+  python3 06_landscape_svg.py --glitch                     (generate + corrupt output)
 
 Palette choices: sunset  blue  purple  red  orange
 
@@ -26,6 +28,7 @@ Install deps:
 import argparse
 import json
 import os
+import random as _random
 import re
 import sys
 import urllib.request
@@ -133,7 +136,8 @@ def _build_prompt(palette: dict, has_mountains: bool, has_clouds: bool,
     horizon_y = int(h * 0.50)
     ground_y  = int(h * 0.76)
 
-    # Collect the ordered feature list (back to front)
+    # Ordered feature list: back to front. Earlier = rendered first = visually behind.
+    # Sun/moon comes BEFORE mountains so mountain peaks occlude it naturally.
     features: list[str] = [
         f"Sky: full-background <rect> using a 3-stop linearGradient id='sky' "
         f"({p['sky_top']} → {p['sky_mid']} → {p['sky_bottom']}, vertical)",
@@ -146,6 +150,12 @@ def _build_prompt(palette: dict, has_mountains: bool, has_clouds: bool,
     features.append(
         f"Atmospheric glow: one wide <ellipse> centered near y={horizon_y}, "
         f"fill={p['atmosphere']}, opacity 0.15-0.30, no stroke"
+    )
+    # Sun here — before mountains, so mountain silhouettes overlap it
+    features.append(
+        f"Sun or moon: <circle> r=28-44, center near x={int(w*0.25)}-{int(w*0.75)}, "
+        f"y={int(h*0.12)}-{int(h*0.42)}, fill={p['sun']} "
+        f"[MUST appear before mountain layers so peaks occlude it]"
     )
     if has_clouds:
         features.append(
@@ -161,12 +171,10 @@ def _build_prompt(palette: dict, has_mountains: bool, has_clouds: bool,
             f"Near mountains: <polygon> peaks at y={int(h*0.52)}-{int(h*0.68)}, "
             f"fill={p['mountain_near']} — must start 0,{h} and end {w},{h}",
         ]
-    features += [
-        f"Sun or moon: <circle> r=28-44, center near x={int(w*0.25)}-{int(w*0.75)}, "
-        f"y={int(h*0.38)}-{int(h*0.54)}, fill={p['sun']}",
+    features.append(
         f"Ground: <rect x='0' y='{ground_y}' width='{w}' height='{h - ground_y}' "
-        f"fill={p['ground']}>",
-    ]
+        f"fill={p['ground']}>"
+    )
 
     feature_block = "\n".join(f"  {i+1}. {f}" for i, f in enumerate(features))
 
@@ -198,8 +206,12 @@ def _build_prompt(palette: dict, has_mountains: bool, has_clouds: bool,
         + mountain_rule
         + f"\n{defs_hint}\n"
         f"RULES:\n"
-        f"  - Use ONLY colors from the PALETTE above\n"
+        f"  - Use ONLY colors from the PALETTE above — no invented colors\n"
         f"  - No <text>, no <image>, no <use>, no external hrefs\n"
+        f"  - Sun/moon MUST be drawn before mountain polygons in the SVG so it\n"
+        f"    appears behind the mountains — peaks occlude it, it does NOT float on top\n"
+        f"  - Mountain polygons must close at the canvas bottom (start/end at y={h})\n"
+        f"    so there are no floating ridges or gaps above the ground rect\n"
         f"  - SVG root: <svg xmlns=\"http://www.w3.org/2000/svg\" "
         f"width=\"{w}\" height=\"{h}\">\n\n"
         f"Output ONLY the complete SVG, starting with <svg and ending with </svg>. "
@@ -228,6 +240,91 @@ def _parse_svg(raw: str) -> str | None:
         if any(tag in svg for tag in ("<rect", "<path", "<polygon", "<circle", "<ellipse")):
             return svg
         return None
+
+
+# ── Glitch post-processor ────────────────────────────────────────────────────────
+# SVG is XML text — all effects are string/regex transforms, no second LLM call.
+
+_GLITCH_WRONG_COLORS = [
+    "#FF00FF", "#00FFFF", "#FFFF00", "#FF0044", "#00FF88", "#FF6600",
+]
+_GLITCH_TEXT_CHARS = "▓░█▒╫╬╪┼┴┬├│╣╠═╡╚╔╗╝▄▀■□▪▫◆◇"
+
+
+def _glitch_corrupt_colors(svg: str, rng: _random.Random) -> tuple[str, str]:
+    """Swap roughly half the unique hex colors with saturated wrong-palette values."""
+    hex_pat = re.compile(r"#[0-9A-Fa-f]{6}")
+    unique = list(dict.fromkeys(hex_pat.findall(svg)))
+    if len(unique) < 2:
+        return svg, "corrupt: too few colors to swap"
+    n = max(1, len(unique) // 2)
+    for color in rng.sample(unique, n):
+        svg = svg.replace(color, rng.choice(_GLITCH_WRONG_COLORS))
+    return svg, f"corrupt: replaced {n}/{len(unique)} colors with wrong palette"
+
+
+def _glitch_sun_bleed(svg: str) -> tuple[str, str]:
+    """Move the largest circle (sun/moon) to the final element — renders over mountains."""
+    pat = re.compile(r'<circle\b[^>]*r="(\d+)"[^>]*/>', re.DOTALL)
+    best_match, best_r = None, 0
+    for m in pat.finditer(svg):
+        r = int(m.group(1))
+        if r > best_r:
+            best_r, best_match = r, m
+    if best_match is None or best_r < 20:
+        return svg, "sun-bleed: no sun/moon found"
+    el = best_match.group(0)
+    svg = svg[: best_match.start()] + svg[best_match.end():]
+    svg = svg.replace("</svg>", f"  {el}\n</svg>")
+    return svg, f"sun-bleed: sun (r={best_r}) moved above all mountains"
+
+
+def _glitch_flip(svg: str) -> tuple[str, str]:
+    """Vertically flip the entire scene — sky becomes ground, ground becomes sky."""
+    m = re.match(r"(<svg\b[^>]*>)(.*)(</svg>\s*$)", svg, re.DOTALL)
+    if not m:
+        return svg, "flip: parse failed"
+    opening, body, closing = m.groups()
+    # scale(1,-1) mirrors y-axis; translate(0,-H) shifts back into viewport
+    flipped = (
+        f"{opening}\n"
+        f'<g transform="scale(1,-1) translate(0,-{SVG_H})">{body}</g>\n'
+        f"{closing}"
+    )
+    return flipped, "flip: scene vertically inverted"
+
+
+def _glitch_ghost_text(svg: str, rng: _random.Random) -> tuple[str, str]:
+    """Scatter semi-transparent garbled text fragments across the scene."""
+    frags = []
+    for _ in range(rng.randint(6, 11)):
+        x    = rng.randint(10, SVG_W - 90)
+        y    = rng.randint(20, SVG_H - 20)
+        text = "".join(rng.choices(_GLITCH_TEXT_CHARS, k=rng.randint(4, 14)))
+        fill = rng.choice(_GLITCH_WRONG_COLORS)
+        op   = round(rng.uniform(0.25, 0.75), 2)
+        size = rng.choice([7, 9, 11, 13, 16])
+        frags.append(
+            f'  <text x="{x}" y="{y}" font-family="monospace" font-size="{size}" '
+            f'fill="{fill}" opacity="{op}">{text}</text>'
+        )
+    svg = svg.replace("</svg>", "\n".join(frags) + "\n</svg>")
+    return svg, f"ghost: injected {len(frags)} garbled text elements"
+
+
+def _apply_glitch(svg: str, seed: int | None = None) -> tuple[str, list[str]]:
+    """Apply all glitch effects; return (modified_svg, log_lines)."""
+    rng = _random.Random(seed)
+    log: list[str] = []
+    for fn in (
+        lambda s: _glitch_corrupt_colors(s, rng),
+        _glitch_sun_bleed,
+        _glitch_flip,
+        lambda s: _glitch_ghost_text(s, rng),
+    ):
+        svg, msg = fn(svg)
+        log.append(msg)
+    return svg, log
 
 
 # ── Server helpers ───────────────────────────────────────────────────────────────
@@ -273,6 +370,14 @@ def main() -> None:
     parser.add_argument(
         "--simulate", action="store_true",
         help="Print the prompt but skip the LLM call",
+    )
+    parser.add_argument(
+        "--glitch", action="store_true",
+        help="Post-process the output SVG with glitch effects (saves landscape_glitch.svg)",
+    )
+    parser.add_argument(
+        "--glitch-seed", type=int, default=None,
+        help="Seed for reproducible glitch output (default: random each run)",
     )
     args = parser.parse_args()
 
@@ -342,6 +447,17 @@ def main() -> None:
     out_path.write_text(svg)
     print(f"\n[SVG saved → {out_path.name}]")
     print(f"  open in browser: file://{out_path.resolve()}")
+
+    if args.glitch:
+        glitch_svg, glitch_log = _apply_glitch(svg, seed=args.glitch_seed)
+        glitch_path = out_path.with_stem(out_path.stem + "_glitch")
+        glitch_path.write_text(glitch_svg)
+        print(f"\n[Glitch effects applied:]")
+        for msg in glitch_log:
+            print(f"  {msg}")
+        print(f"\n[Glitch SVG saved → {glitch_path.name}]")
+        print(f"  open in browser: file://{glitch_path.resolve()}")
+
     print(f"\n[Done]")
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tt-vscode-toolkit",
-  "version": "0.0.418",
+  "version": "0.0.419",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tt-vscode-toolkit",
-      "version": "0.0.418",
+      "version": "0.0.419",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "marked": "^17.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tt-vscode-toolkit",
-  "version": "0.0.417",
+  "version": "0.0.418",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tt-vscode-toolkit",
-      "version": "0.0.417",
+      "version": "0.0.418",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "marked": "^17.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tt-vscode-toolkit",
-  "version": "0.0.419",
+  "version": "0.0.420",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tt-vscode-toolkit",
-      "version": "0.0.419",
+      "version": "0.0.420",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "marked": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.418",
+  "version": "0.0.419",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.417",
+  "version": "0.0.418",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.419",
+  "version": "0.0.420",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -659,11 +659,12 @@ function renderLesson(markdownPath) {
 
   html = DOMPurify.sanitize(html, {
     ADD_TAGS: ['button', 'div', 'pre', 'span', 'details', 'summary',
-               'figure', 'figcaption', 'video', 'source'],
+               'figure', 'figcaption', 'video', 'source', 'iframe'],
     ADD_ATTR: ['data-command', 'class', 'data-args', 'data-hw',
                'data-arch', 'data-script',
                'autoplay', 'loop', 'muted', 'playsinline', 'controls',
-               'loading'],
+               'loading',
+               'allowfullscreen', 'frameborder', 'allow'],
   });
 
   // Restore mermaid content
@@ -2135,11 +2136,12 @@ function renderMarkdownPage(filePath) {
   });
   html = DOMPurify.sanitize(html, {
     ADD_TAGS: ['button', 'div', 'pre', 'span', 'details', 'summary',
-               'figure', 'figcaption', 'video', 'source'],
+               'figure', 'figcaption', 'video', 'source', 'iframe'],
     ADD_ATTR: ['data-command', 'class', 'data-args', 'data-hw',
                'data-arch', 'data-script',
                'autoplay', 'loop', 'muted', 'playsinline', 'controls',
-               'loading'],
+               'loading',
+               'allowfullscreen', 'frameborder', 'allow'],
   });
   mermaidBlocks.forEach((mc, i) => {
     html = html.replace(`${MERMAID_PH}${i}`, mc);

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -405,6 +405,16 @@ WEB_RENDERER.heading = function ({ tokens, depth }) {
   return `<h${depth} id="${escapeAttr(id)}">${escapeHtml(text)}</h${depth}>\n`;
 };
 
+// Rewrite absolute image src paths through siteUrl() so they resolve correctly
+// on GitHub Pages (SITE_BASE_PATH=/tt-vscode-toolkit).  Without this, a src of
+// "/assets/img/foo.svg" in markdown renders as-is, which on the live site
+// resolves to the domain root rather than the sub-path the site lives under.
+WEB_RENDERER.image = function ({ href, title, text }) {
+  const src = href && href.startsWith('/') ? siteUrl(href) : (href || '');
+  const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+  return `<img src="${escapeAttr(src)}" alt="${escapeHtml(text || '')}"${titleAttr}>`;
+};
+
 WEB_RENDERER.link = function ({ href, title, tokens }) {
   const text = extractText(tokens);
 

--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -245,6 +245,23 @@ export class MarkdownRenderer {
         return `<pre class="mermaid">${mermaidPlaceholder}${mermaidBlocks.length - 1}</pre>`;
       });
 
+      // YouTube iframes fail in VSCode webviews with Error 153 — the vscode-webview://
+      // scheme is blocked by YouTube's embed server. Replace with a thumbnail linked to
+      // the watch URL *before* sanitization so the generated HTML is covered by the sanitizer.
+      // Clicking opens in the system browser via the openExternal handler.
+      html = html.replace(
+        /<div[^>]*>\s*<iframe[^>]+src="https:\/\/www\.youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]+)[^"]*"[^>]*><\/iframe>\s*<\/div>/gis,
+        (_, videoId) => {
+          const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+          const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+          return (
+            `<a href="${watchUrl}" title="Watch on YouTube" style="display:block;margin:24px 0;">` +
+            `<img src="${thumbUrl}" alt="Watch on YouTube" style="width:100%;border-radius:6px;" loading="eager">` +
+            `</a>`
+          );
+        }
+      );
+
       // Sanitize everything else using sanitize-html (pure JS, no DOM/jsdom dependency)
       html = sanitizeHtml(html, {
         allowedTags: sanitizeHtml.defaults.allowedTags.concat([
@@ -267,8 +284,8 @@ export class MarkdownRenderer {
           'button': ['class', 'data-command', 'data-args', 'title'],
           'pre': ['class'],
           'code': ['class'],
-          'a': ['href', 'title', 'target'],
-          'img': ['src', 'alt', 'title', 'loading'],
+          'a': ['href', 'title', 'target', 'style'],
+          'img': ['src', 'alt', 'title', 'loading', 'style'],
           'canvas': ['class', 'width', 'height'],
           'iframe': ['src', 'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'title', 'style'],
         },
@@ -286,22 +303,6 @@ export class MarkdownRenderer {
         html = html.replace(`${mermaidPlaceholder}${index}`, content);
       });
     }
-
-    // YouTube iframes fail in VSCode webviews with Error 153 — the vscode-webview://
-    // scheme is blocked by YouTube's embed server. Replace with a thumbnail linked to
-    // the watch URL; clicking opens in the system browser via the openExternal handler.
-    html = html.replace(
-      /<div[^>]*>\s*<iframe[^>]+src="https:\/\/www\.youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]+)[^"]*"[^>]*><\/iframe>\s*<\/div>/gis,
-      (_, videoId) => {
-        const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
-        const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
-        return (
-          `<a href="${watchUrl}" title="Watch on YouTube" style="display:block;margin:24px 0;">` +
-          `<img src="${thumbUrl}" alt="Watch on YouTube" style="width:100%;border-radius:6px;" loading="eager">` +
-          `</a>`
-        );
-      }
-    );
 
     // Extract command IDs from HTML
     const commands = this.extractCommands(html);

--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -288,22 +288,17 @@ export class MarkdownRenderer {
     }
 
     // YouTube iframes fail in VSCode webviews with Error 153 — the vscode-webview://
-    // scheme is blocked by YouTube's embed server. Replace any YouTube iframe (with its
-    // responsive wrapper div) with a clickable thumbnail that opens in the system browser.
+    // scheme is blocked by YouTube's embed server. Replace with a thumbnail linked to
+    // the watch URL; clicking opens in the system browser via the openExternal handler.
     html = html.replace(
       /<div[^>]*>\s*<iframe[^>]+src="https:\/\/www\.youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]+)[^"]*"[^>]*><\/iframe>\s*<\/div>/gis,
       (_, videoId) => {
-        const watchUrl  = `https://www.youtube.com/watch?v=${videoId}`;
-        const thumbUrl  = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+        const watchUrl = `https://www.youtube.com/watch?v=${videoId}`;
+        const thumbUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
         return (
-          `<a href="${watchUrl}" title="Watch on YouTube" ` +
-          `style="display:block;position:relative;margin:24px 0;border-radius:6px;overflow:hidden;cursor:pointer;">` +
-          `<img src="${thumbUrl}" alt="Watch on YouTube" style="width:100%;display:block;" loading="eager">` +
-          `<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.35);">` +
-          `<svg width="68" height="48" viewBox="0 0 68 48" xmlns="http://www.w3.org/2000/svg">` +
-          `<path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79 0 34 0 34 0S12.21 0 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C0 13.05 0 24 0 24s0 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 48 34 48 34 48s21.79 0 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C68 34.95 68 24 68 24s0-10.95-1.48-16.26z" fill="#FF0000"/>` +
-          `<path d="M27 34l18-10-18-10v20z" fill="#fff"/>` +
-          `</svg></div></a>`
+          `<a href="${watchUrl}" title="Watch on YouTube" style="display:block;margin:24px 0;">` +
+          `<img src="${thumbUrl}" alt="Watch on YouTube" style="width:100%;border-radius:6px;" loading="eager">` +
+          `</a>`
         );
       }
     );

--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -251,6 +251,7 @@ export class MarkdownRenderer {
           'button', 'pre', 'div', 'span', 'details', 'summary',
           'table', 'thead', 'tbody', 'tr', 'th', 'td', 'img',
           'canvas',  // tensix-viz grid
+          'iframe',  // YouTube embeds (hostname-restricted below)
         ]),
         allowedAttributes: {
           ...sanitizeHtml.defaults.allowedAttributes,
@@ -269,12 +270,15 @@ export class MarkdownRenderer {
           'a': ['href', 'title', 'target'],
           'img': ['src', 'alt', 'title', 'loading'],
           'canvas': ['class', 'width', 'height'],
+          'iframe': ['src', 'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'title', 'style'],
         },
         // Allow vscode-webview / vscode-resource URI schemes used by webview.asWebviewUri()
         // in addition to the sanitize-html defaults (http, https, ftp, mailto, //)
         allowedSchemesByTag: {
           'img': ['http', 'https', 'data', 'vscode-webview', 'vscode-resource'],
         },
+        // Restrict iframe src to trusted video hosts only
+        allowedIframeHostnames: ['www.youtube.com', 'www.youtube-nocookie.com'],
       });
 
       // Restore mermaid blocks with original unsanitized content

--- a/src/renderers/MarkdownRenderer.ts
+++ b/src/renderers/MarkdownRenderer.ts
@@ -287,6 +287,27 @@ export class MarkdownRenderer {
       });
     }
 
+    // YouTube iframes fail in VSCode webviews with Error 153 — the vscode-webview://
+    // scheme is blocked by YouTube's embed server. Replace any YouTube iframe (with its
+    // responsive wrapper div) with a clickable thumbnail that opens in the system browser.
+    html = html.replace(
+      /<div[^>]*>\s*<iframe[^>]+src="https:\/\/www\.youtube(?:-nocookie)?\.com\/embed\/([A-Za-z0-9_-]+)[^"]*"[^>]*><\/iframe>\s*<\/div>/gis,
+      (_, videoId) => {
+        const watchUrl  = `https://www.youtube.com/watch?v=${videoId}`;
+        const thumbUrl  = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+        return (
+          `<a href="${watchUrl}" title="Watch on YouTube" ` +
+          `style="display:block;position:relative;margin:24px 0;border-radius:6px;overflow:hidden;cursor:pointer;">` +
+          `<img src="${thumbUrl}" alt="Watch on YouTube" style="width:100%;display:block;" loading="eager">` +
+          `<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,0.35);">` +
+          `<svg width="68" height="48" viewBox="0 0 68 48" xmlns="http://www.w3.org/2000/svg">` +
+          `<path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79 0 34 0 34 0S12.21 0 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C0 13.05 0 24 0 24s0 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 48 34 48 34 48s21.79 0 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C68 34.95 68 24 68 24s0-10.95-1.48-16.26z" fill="#FF0000"/>` +
+          `<path d="M27 34l18-10-18-10v20z" fill="#fff"/>` +
+          `</svg></div></a>`
+        );
+      }
+    );
+
     // Extract command IDs from HTML
     const commands = this.extractCommands(html);
 

--- a/src/views/LessonWebviewManager.ts
+++ b/src/views/LessonWebviewManager.ts
@@ -404,7 +404,15 @@ export class LessonWebviewManager {
 
       case 'openExternal':
         if (message.url) {
-          await vscode.env.openExternal(vscode.Uri.parse(message.url));
+          try {
+            const uri = vscode.Uri.parse(message.url);
+            const allowedSchemes = new Set(['http', 'https']);
+            if (allowedSchemes.has(uri.scheme.toLowerCase())) {
+              await vscode.env.openExternal(uri);
+            }
+          } catch {
+            // Ignore invalid or unsupported URLs from the webview
+          }
         }
         break;
 

--- a/src/views/LessonWebviewManager.ts
+++ b/src/views/LessonWebviewManager.ts
@@ -23,11 +23,12 @@ import { getNonce } from '../utils/webview';
  * Message types for webview communication
  */
 interface WebviewMessage {
-  type: 'executeCommand' | 'copyCode' | 'ready';
+  type: 'executeCommand' | 'copyCode' | 'ready' | 'openExternal';
   command?: string;
   code?: string;
   args?: any; // Command arguments (lessonId, hardware, etc.)
   lessonId?: string; // Deprecated - use args.lessonId instead
+  url?: string; // For openExternal messages
 }
 
 /**
@@ -398,6 +399,12 @@ export class LessonWebviewManager {
               this.currentLesson
             );
           }
+        }
+        break;
+
+      case 'openExternal':
+        if (message.url) {
+          await vscode.env.openExternal(vscode.Uri.parse(message.url));
         }
         break;
 

--- a/src/views/LessonWebviewManager.ts
+++ b/src/views/LessonWebviewManager.ts
@@ -217,7 +217,7 @@ export class LessonWebviewManager {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${this.panel!.webview.cspSource} 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'nonce-${nonce}' ${this.panel!.webview.cspSource} https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; img-src ${this.panel!.webview.cspSource} https: data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${this.panel!.webview.cspSource} 'unsafe-inline' https://cdnjs.cloudflare.com; script-src 'nonce-${nonce}' ${this.panel!.webview.cspSource} https://cdnjs.cloudflare.com https://cdn.jsdelivr.net; img-src ${this.panel!.webview.cspSource} https: data:; frame-src https://www.youtube.com https://www.youtube-nocookie.com;">
   <title>${this.escapeHtml(lesson.title)}</title>
   <link rel="stylesheet" href="${cssUri}">
   ${tensixVizCssUri ? `<link rel="stylesheet" href="${tensixVizCssUri}">` : ''}

--- a/src/webview/scripts/lesson-viewer.js
+++ b/src/webview/scripts/lesson-viewer.js
@@ -17,6 +17,7 @@
    */
   function initialize() {
     setupCommandButtons();
+    setupExternalLinks();
     setupCodeBlocks();
     restoreScrollPosition();
   }
@@ -60,6 +61,22 @@
           }, 2000);
         }
       });
+    });
+  }
+
+  /**
+   * Intercept external http/https link clicks and open them in the system browser.
+   * VSCode webviews don't navigate external URLs on their own.
+   */
+  function setupExternalLinks() {
+    document.addEventListener('click', function(event) {
+      const anchor = event.target.closest('a[href]');
+      if (!anchor) { return; }
+      const href = anchor.getAttribute('href');
+      if (href && (href.startsWith('http://') || href.startsWith('https://'))) {
+        event.preventDefault();
+        vscode.postMessage({ type: 'openExternal', url: href });
+      }
     });
   }
 

--- a/src/webview/scripts/lesson-viewer.js
+++ b/src/webview/scripts/lesson-viewer.js
@@ -70,6 +70,7 @@
    */
   function setupExternalLinks() {
     document.addEventListener('click', function(event) {
+      if (!(event.target instanceof Element)) { return; }
       const anchor = event.target.closest('a[href]');
       if (!anchor) { return; }
       const href = anchor.getAttribute('href');


### PR DESCRIPTION
## Summary

- **Image path fix (v0.0.418)** — added `WEB_RENDERER.image` handler in `scripts/build-web.js` to rewrite absolute `/assets/img/...` paths through `siteUrl()`, fixing 404s on the GitHub Pages deploy where `SITE_BASE_PATH=/tt-vscode-toolkit`
- **YouTube iframe → thumbnail fallback** — replaced YouTube `<iframe>` embeds in the webview with a static thumbnail + link, resolving VSCode Error 153 (CSP blocks iframes from external origins); external video links open in the system browser via `openExternal`
- **External links in system browser** — added `openExternal` message handler in `LessonWebviewManager.ts` and click-intercept in `lesson-viewer.js` so external links open in the OS browser rather than inside the webview
- **QB2 agents lesson** — expanded `qb2-local-agents.md` with YouTube embed, glitch-art lesson section, and template sync; updated `06_landscape_svg.py` template with additional scene generation

## Test plan

- [ ] Build passes: `npm run build` ✅ (v0.0.419, all validators green)
- [ ] Verify lesson images load on live site after deploy (`/tt-vscode-toolkit/assets/img/...`)
- [ ] Open QB2 agents lesson in extension — YouTube section shows thumbnail + link, not iframe
- [ ] Click an external link in a lesson — opens in system browser (not inside webview)
- [ ] Light-mode OS: install page hero, tagline, and code chip text remain readable