### PR TITLE
fix(web): add light-mode syntax highlighting overrides to lesson page…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.429] - 2026-05-07
+
+### Fixed
+
+- **Website light mode — syntax highlighting** — `scripts/build-web.js` now emits a `@media (prefers-color-scheme: light)` block for all `.hljs` token classes. Previously every token color was hardcoded for the dark Tenstorrent palette (`#E8F0F2` base, `#4FD1C5` teal keywords, `#81E6D9` light-teal variables, etc.) which were near-invisible or low-contrast on white backgrounds. Light-mode overrides now use the VS Code Light+ palette: dark navy keywords (`#0000ff`), burgundy strings (`#a31515`), green comments/numbers (`#008000` / `#098658`), brown function names (`#795e26`), teal-blue types (`#267f99`), and dark navy variables (`#001080`).
+
+---
+
 ## [0.0.428] - 2026-04-30
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tt-vscode-toolkit",
-  "version": "0.0.421",
+  "version": "0.0.429",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tt-vscode-toolkit",
-      "version": "0.0.421",
+      "version": "0.0.429",
       "dependencies": {
         "gray-matter": "^4.0.3",
         "marked": "^17.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.428",
+  "version": "0.0.429",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -2019,6 +2019,97 @@ body.page-install .lesson-content {
   color: #4FD1C5;
   text-decoration: underline;
 }
+
+/* ===== Syntax highlighting — light mode overrides ===== */
+/*
+ * Replaces the dark palette with VS Code Light+ / docs.tenstorrent.com colours
+ * so code blocks are readable when the OS/browser is in light mode.
+ */
+@media (prefers-color-scheme: light) {
+  .hljs {
+    color: #1e1e1e;          /* near-black base */
+  }
+
+  .hljs-keyword,
+  .hljs-operator,
+  .hljs-selector-tag,
+  .hljs-built_in,
+  .hljs-builtin-name {
+    color: #0000ff;          /* blue — VS Code Light+ keyword */
+    font-weight: bold;
+  }
+
+  .hljs-string,
+  .hljs-template-variable,
+  .hljs-doctag,
+  .hljs-regexp {
+    color: #a31515;          /* burgundy — VS Code Light+ string */
+  }
+
+  .hljs-number,
+  .hljs-literal {
+    color: #098658;          /* green — numeric literals */
+  }
+
+  .hljs-title,
+  .hljs-title.function_,
+  .hljs-title.function_.invoke__ {
+    color: #795e26;          /* brown — function names */
+  }
+
+  .hljs-title.class_,
+  .hljs-type,
+  .hljs-symbol {
+    color: #267f99;          /* teal-blue — types */
+  }
+
+  .hljs-variable,
+  .hljs-variable.language_,
+  .hljs-params,
+  .hljs-attr {
+    color: #001080;          /* dark navy — variables */
+  }
+
+  .hljs-comment,
+  .hljs-quote {
+    color: #008000;          /* green — comments */
+    font-style: italic;
+  }
+
+  .hljs-tag,
+  .hljs-name {
+    color: #800000;          /* maroon — HTML/XML tags */
+  }
+
+  .hljs-attribute {
+    color: #e50000;          /* red — attribute names */
+  }
+
+  .hljs-meta,
+  .hljs-meta .hljs-keyword {
+    color: #0000ff;          /* blue — decorators, directives */
+  }
+
+  .hljs-section {
+    color: #795e26;
+    font-weight: bold;
+  }
+
+  .hljs-addition {
+    color: #1a8737;
+    background: rgba(26, 135, 55, 0.12);
+  }
+
+  .hljs-deletion {
+    color: #c41a16;
+    background: rgba(196, 26, 22, 0.12);
+  }
+
+  .hljs-link {
+    color: #0070c1;
+    text-decoration: underline;
+  }
+}
 `;
 
 


### PR DESCRIPTION
…s (v0.0.429)

All .hljs token colors in the generated lesson-web.css were hardcoded for the dark Tenstorrent palette and were invisible/low-contrast on white backgrounds (OS/browser light mode).

Adds a @media (prefers-color-scheme: light) block in build-web.js webLayoutCss() covering all hljs token classes, using the VS Code Light+ palette: dark navy keywords, burgundy strings, green comments, brown function names, teal-blue types, dark navy variables.

The CSS variable system (lesson-web-vars.css) already had correct light-mode overrides for all layout/UI colors; this completes coverage for syntax-highlighted code blocks.


- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [X] 🎨 Style/formatting change (no functional changes)
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🎓 New lesson or lesson content update
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update
- [ ] 🔧 Build/tooling change

<img width="907" height="682" alt="Screenshot 2026-05-07 at 3 14 00 PM" src="https://github.com/user-attachments/assets/d3ab30c0-e0a1-4199-a48f-67a232d5ee80" />
