### PR TITLE
Fix auto-link nesting in href attributes and add validation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.466] - 2026-06-09
+
+### Fixed
+
+- **Auto-link nested-anchor bug** — `autoLinkFirstMentions` in `build-web.js` was mutating the text segment in-place then continuing to match shorter terms (e.g. `tt-metal`) inside the href of an already-inserted anchor (e.g. `TT-Metalium`), producing `<a href="...<a href=...>tt-metal</a>...">TT-Metalium</a>`. Fixed by breaking out of the term loop after the first substitution per text node. Added a new link-validator test scanning all built site HTML for `href` attributes containing literal `<a` strings to catch regressions.
+
+---
+
 ## [0.0.465] - 2026-06-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.465",
+  "version": "0.0.466",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -146,6 +146,7 @@ function autoLinkFirstMentions(html) {
         + `<a href="${escapeAttr(url)}" target="_blank" rel="noreferrer">${term}</a>`
         + text.slice(idx + term.length);
       linked.add(term);
+      break; // only one substitution per text node — prevents matching inside injected href values
     }
     return text;
   }).join('');

--- a/test/link-validator.test.ts
+++ b/test/link-validator.test.ts
@@ -329,6 +329,45 @@ describe('Internal Link Validation', () => {
         }
     });
 
+    it('should have no nested <a> tags inside href attributes in built site HTML', () => {
+        // Catches the auto-link bug where a term gets substituted inside the href of a
+        // previously auto-linked anchor, producing <a href="...<a href=...>term</a>...">.
+        const siteDir = path.join(projectRoot, 'site');
+        if (!fs.existsSync(siteDir)) {
+            console.warn('\n⚠️  site/ not built — skipping nested-anchor check (run node scripts/build-web.js first)\n');
+            return;
+        }
+
+        const nestedAnchorErrors: string[] = [];
+
+        function walkSite(dir: string) {
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const fullPath = path.join(dir, entry.name);
+                if (entry.isDirectory()) { walkSite(fullPath); continue; }
+                if (!entry.name.endsWith('.html')) continue;
+
+                const html = fs.readFileSync(fullPath, 'utf-8');
+                const relPath = path.relative(projectRoot, fullPath);
+
+                // Find <a ...> where the href value contains a literal "<a"
+                const hrefRe = /href="([^"]*<a[^"]*)"/g;
+                let m: RegExpExecArray | null;
+                while ((m = hrefRe.exec(html)) !== null) {
+                    nestedAnchorErrors.push(`${relPath} — nested <a> in href: href="${m[1].slice(0, 80)}..."`);
+                }
+            }
+        }
+
+        walkSite(siteDir);
+
+        if (nestedAnchorErrors.length > 0) {
+            assert.fail(
+                `Found ${nestedAnchorErrors.length} href attributes containing nested <a> tags (auto-link bug):\n` +
+                `  ${nestedAnchorErrors.join('\n  ')}`
+            );
+        }
+    });
+
     it('should have all lessons in registry referenced somewhere in documentation', () => {
         // This is a warning test - lessons not referenced anywhere might be orphaned
         const allContent: string[] = [];

--- a/test/link-validator.test.ts
+++ b/test/link-validator.test.ts
@@ -329,44 +329,48 @@ describe('Internal Link Validation', () => {
         }
     });
 
-    it('should have no nested <a> tags inside href attributes in built site HTML', () => {
+    it('should have no nested <a> tags inside href attributes in built site HTML', function () {
         // Catches the auto-link bug where a term gets substituted inside the href of a
         // previously auto-linked anchor, producing <a href="...<a href=...>term</a>...">.
-        const siteDir = path.join(projectRoot, 'site');
-        if (!fs.existsSync(siteDir)) {
-            // Build the site on-demand so this test always runs, even in the default
-            // `npm run test:links` flow where the site is not pre-built.
-            const { execSync } = require('child_process');
-            execSync('node scripts/build-web.js', { cwd: projectRoot, stdio: 'inherit' });
-        }
+        // Always builds into a temp directory so the scan is never stale.
+        this.timeout(60000);
 
-        const nestedAnchorErrors: string[] = [];
+        const { execSync } = require('child_process');
+        const os = require('os');
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tt-site-'));
+        try {
+            execSync(`node scripts/build-web.js --out ${tmpDir}`, { cwd: projectRoot, stdio: 'inherit' });
 
-        function walkSite(dir: string) {
-            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                const fullPath = path.join(dir, entry.name);
-                if (entry.isDirectory()) { walkSite(fullPath); continue; }
-                if (!entry.name.endsWith('.html')) continue;
+            const nestedAnchorErrors: string[] = [];
 
-                const html = fs.readFileSync(fullPath, 'utf-8');
-                const relPath = path.relative(projectRoot, fullPath);
+            function walkSite(dir: string) {
+                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                    const fullPath = path.join(dir, entry.name);
+                    if (entry.isDirectory()) { walkSite(fullPath); continue; }
+                    if (!entry.name.endsWith('.html')) continue;
 
-                // Find <a ...> where the href value contains a literal "<a"
-                const hrefRe = /href="([^"]*<a[^"]*)"/g;
-                let m: RegExpExecArray | null;
-                while ((m = hrefRe.exec(html)) !== null) {
-                    nestedAnchorErrors.push(`${relPath} — nested <a> in href: href="${m[1].slice(0, 80)}..."`);
+                    const html = fs.readFileSync(fullPath, 'utf-8');
+                    const relPath = path.relative(tmpDir, fullPath);
+
+                    // Find <a ...> where the href value contains a literal "<a"
+                    const hrefRe = /href="([^"]*<a[^"]*)"/g;
+                    let m: RegExpExecArray | null;
+                    while ((m = hrefRe.exec(html)) !== null) {
+                        nestedAnchorErrors.push(`${relPath} — nested <a> in href: href="${m[1].slice(0, 80)}..."`);
+                    }
                 }
             }
-        }
 
-        walkSite(siteDir);
+            walkSite(tmpDir);
 
-        if (nestedAnchorErrors.length > 0) {
-            assert.fail(
-                `Found ${nestedAnchorErrors.length} href attributes containing nested <a> tags (auto-link bug):\n` +
-                `  ${nestedAnchorErrors.join('\n  ')}`
-            );
+            if (nestedAnchorErrors.length > 0) {
+                assert.fail(
+                    `Found ${nestedAnchorErrors.length} href attributes containing nested <a> tags (auto-link bug):\n` +
+                    `  ${nestedAnchorErrors.join('\n  ')}`
+                );
+            }
+        } finally {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
         }
     });
 

--- a/test/link-validator.test.ts
+++ b/test/link-validator.test.ts
@@ -334,8 +334,10 @@ describe('Internal Link Validation', () => {
         // previously auto-linked anchor, producing <a href="...<a href=...>term</a>...">.
         const siteDir = path.join(projectRoot, 'site');
         if (!fs.existsSync(siteDir)) {
-            console.warn('\n⚠️  site/ not built — skipping nested-anchor check (run node scripts/build-web.js first)\n');
-            return;
+            // Build the site on-demand so this test always runs, even in the default
+            // `npm run test:links` flow where the site is not pre-built.
+            const { execSync } = require('child_process');
+            execSync('node scripts/build-web.js', { cwd: projectRoot, stdio: 'inherit' });
         }
 
         const nestedAnchorErrors: string[] = [];


### PR DESCRIPTION
autoLinkFirstMentions mutated the text segment in-place and kept iterating terms, so a shorter term (tt-metal) matched inside the href of an already-inserted anchor (TT-Metalium), producing a nested <a> inside an href value.

Fix: break after the first substitution per text node — only one auto-link per plain-text segment is safe.

Add test: link-validator now scans all built site/ HTML for href attributes containing literal '<a', catching this class of regression before it ships (v0.0.466).
