### PR TITLE
Audit QB2 for Ubuntu 24.04 compatibility and update Python usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **QB2 / Ubuntu 24.04 compatibility audit across cookbook and deployment lessons** — comprehensive pass to ensure all lessons work on tt-developer-image, QB2 pre-installed images, and cloud/custom installs:
   - `python` → `python3` throughout (`cookbook-game-of-life`, `cookbook-audio-processor`, `cookbook-mandelbrot`, `cookbook-image-filters`, `cookbook-particle-life`, `deploy-to-koyeb`, `vllm-production`). Ubuntu 24.04 and tt-developer-image have no `python` symlink.
-  - Venv activation blocks updated to dual-path pattern showing `tt-metal` shell switcher (tt-developer-image/Docker), `~/.tenstorrent-venv` (QB2 pre-installed), and `/opt/venv-metal` (cloud/custom) in all affected cookbook lessons.
+  - Venv activation blocks updated to three-path pattern showing `tt-metal` shell switcher (tt-developer-image/Docker), `~/.tenstorrent-venv` (QB2 pre-installed), and `/opt/venv-metal` (cloud/custom) in all affected cookbook lessons.
   - `vllm-production`: replaced broken `~/tt-metal/build/python_env_vllm` verify block with `python3 -c "import vllm"`; all 12 server launch blocks updated to use `tt-vllm` / `~/.tenstorrent-venv` / `~/activate-vllm-env.sh` / `/opt/venv-vllm` multi-path pattern; all `source ~/activate-vllm-env.sh &&` prefixes removed from run commands.
   - `cookbook-particle-life`: fixed multi-device "Key Code Pattern" from broken per-chip `open_device` loop (causes dispatch core errors on teardown) to `ttnn.CreateDevices` / `ttnn.CloseDevices` coordinated API.
   - `deploy-to-koyeb`: `python -m vllm` → `python3 -m vllm` in review block and all Dockerfile CMD entries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.0.504] - 2026-06-23
+### Fixed
+- **QB2 / Ubuntu 24.04 compatibility audit across cookbook and deployment lessons** — comprehensive pass to ensure all lessons work on tt-developer-image, QB2 pre-installed images, and cloud/custom installs:
+  - `python` → `python3` throughout (`cookbook-game-of-life`, `cookbook-audio-processor`, `cookbook-mandelbrot`, `cookbook-image-filters`, `cookbook-particle-life`, `deploy-to-koyeb`, `vllm-production`). Ubuntu 24.04 and tt-developer-image have no `python` symlink.
+  - Venv activation blocks updated to dual-path pattern showing `tt-metal` shell switcher (tt-developer-image/Docker), `~/.tenstorrent-venv` (QB2 pre-installed), and `/opt/venv-metal` (cloud/custom) in all affected cookbook lessons.
+  - `vllm-production`: replaced broken `~/tt-metal/build/python_env_vllm` verify block with `python3 -c "import vllm"`; all 12 server launch blocks updated to use `tt-vllm` / `~/.tenstorrent-venv` / `~/activate-vllm-env.sh` / `/opt/venv-vllm` multi-path pattern; all `source ~/activate-vllm-env.sh &&` prefixes removed from run commands.
+  - `cookbook-particle-life`: fixed multi-device "Key Code Pattern" from broken per-chip `open_device` loop (causes dispatch core errors on teardown) to `ttnn.CreateDevices` / `ttnn.CloseDevices` coordinated API.
+  - `deploy-to-koyeb`: `python -m vllm` → `python3 -m vllm` in review block and all Dockerfile CMD entries.
+
 ## [0.0.503] - 2026-06-12
 ### Fixed
 - **Self-review fixes** — 29 issues confirmed by automated adversarial review: corrected MESH_DEVICE enum values in code-fence comments (T3000→T3K, n150→N150, Galaxy→GALAXY throughout vllm-production, image-generation, bounty-program, version-compatibility, step-zero, README); removed `<sup>™/</sup>` HTML injected into yaml/bash code fences (ct3-configuration-patterns, step-zero); fixed api-server print string back to `tt-metal ready`; corrected `p100`→`P100` in hardware-detection and QB_follows prose; completed T3K→T3000 normalization in ttsim/cookbook-particle-life prose callouts; fixed FAQ duplicate stale QB2 paragraph and TTNN/tt-metal prose table cells; fixed bare `tt-metal` prose in image-generation (→ TT-Metalium); updated link display text in cookbook-overview and tt-inference-server (github URL→ product name); clarified Vale config comments (ProductNames.yml T3000 exception, Terminology.yml link-text caveat).

--- a/content/lessons/cookbook-audio-processor.md
+++ b/content/lessons/cookbook-audio-processor.md
@@ -748,6 +748,11 @@ class SpectrogramVisualizer:
 ```bash
 cd ~/tt-scratchpad/cookbook/audio_processor
 
+# Activate TT environment (choose for your setup):
+tt-metal                                          # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source /opt/venv-metal/bin/activate             # cloud / custom install
+
 # Install dependencies
 pip install -r requirements.txt
 
@@ -761,7 +766,7 @@ print('Created examples/sample.wav')
 "
 
 # Process an audio file
-python processor.py examples/sample.wav
+python3 processor.py examples/sample.wav
 ```
 
 > **Note:** `processor.py` is a starter template. The mel-spectrogram uses librosa
@@ -771,7 +776,7 @@ python processor.py examples/sample.wav
 **Try audio effects:**
 
 ```bash
-python -c "
+python3 -c "
 from processor import AudioProcessor
 from effects import AudioEffects
 import ttnn
@@ -803,7 +808,7 @@ ttnn.close_device(device)
 **Real-time spectrogram from microphone:**
 
 ```bash
-python -c "
+python3 -c "
 from processor import AudioProcessor
 from visualizer import SpectrogramVisualizer
 import ttnn

--- a/content/lessons/cookbook-game-of-life.md
+++ b/content/lessons/cookbook-game-of-life.md
@@ -404,17 +404,22 @@ def compare_patterns(patterns_dict):
 ```bash
 cd ~/tt-scratchpad/cookbook/game_of_life
 
+# Activate TT environment (choose for your setup):
+tt-metal                                          # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source /opt/venv-metal/bin/activate             # cloud / custom install
+
 # Install dependencies
 pip install -r requirements.txt
 
 # Run with random initial state
-python game_of_life.py
+python3 game_of_life.py
 ```
 
 **Run with specific pattern:**
 
 ```bash
-python -c "
+python3 -c "
 from game_of_life import GameOfLife
 from visualizer import animate_game_of_life
 import ttnn

--- a/content/lessons/cookbook-image-filters.md
+++ b/content/lessons/cookbook-image-filters.md
@@ -315,6 +315,11 @@ if __name__ == "__main__":
 ```bash
 cd ~/tt-scratchpad/cookbook/image_filters
 
+# Activate TT environment (choose for your setup):
+tt-metal                                          # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source /opt/venv-metal/bin/activate             # cloud / custom install
+
 # Install dependencies
 pip install -r requirements.txt
 
@@ -325,7 +330,7 @@ from PIL import Image; import numpy as np
 Image.fromarray(np.random.randint(0,255,(256,256,3), dtype=np.uint8)).save('examples/sample.jpg')
 print('Created examples/sample.jpg')
 "
-python filters.py examples/sample.jpg
+python3 filters.py examples/sample.jpg
 ```
 
 > The script uses `examples/sample.jpg` by default. In a headless environment

--- a/content/lessons/cookbook-mandelbrot.md
+++ b/content/lessons/cookbook-mandelbrot.md
@@ -507,14 +507,19 @@ class MandelbrotVisualizer:
 ```bash
 cd ~/tt-scratchpad/cookbook/mandelbrot
 
+# Activate TT environment (choose for your setup):
+tt-metal                                          # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source /opt/venv-metal/bin/activate             # cloud / custom install
+
 # Basic render
-python renderer.py
+python3 renderer.py
 ```
 
 **Interactive explorer:**
 
 ```bash
-python -c "
+python3 -c "
 from renderer import MandelbrotRenderer
 from explorer import MandelbrotVisualizer
 import ttnn
@@ -533,7 +538,7 @@ ttnn.close_device(device)
 **Compare Julia sets:**
 
 ```bash
-python -c "
+python3 -c "
 from renderer import MandelbrotRenderer
 from explorer import MandelbrotVisualizer
 import ttnn

--- a/content/lessons/cookbook-particle-life.md
+++ b/content/lessons/cookbook-particle-life.md
@@ -233,7 +233,7 @@ devices = ttnn.CreateDevices(list(range(num_devices)))
 try:
     # Create multi-device simulation
     sim = ParticleLifeMultiDevice(
-        devices=devices,  # Dict of device_id → device handle
+        devices=devices,  # list of device handles from CreateDevices
         num_particles=2048,
         num_species=3
     )

--- a/content/lessons/cookbook-particle-life.md
+++ b/content/lessons/cookbook-particle-life.md
@@ -86,11 +86,16 @@ This creates the project in `~/tt-scratchpad/cookbook/particle_life/`.
 ```bash
 cd ~/tt-scratchpad/cookbook/particle_life
 
+# Activate TT environment (choose for your setup):
+tt-metal                                          # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source /opt/venv-metal/bin/activate             # cloud / custom install
+
 # Run simulation (creates particle_life.gif)
-python test_particle_life.py
+python3 test_particle_life.py
 
 # Or run directly with custom parameters
-python particle_life.py --num-particles 2048 --num-steps 500 --species 3
+python3 particle_life.py --num-particles 2048 --num-steps 500 --species 3
 ```
 
 **What you'll see:**
@@ -220,20 +225,23 @@ The `particle_life_multi_device.py` script extends the original implementation w
 **Key Code Pattern:**
 
 ```python
-# Open all available devices
-devices = []
-for device_id in range(num_devices):
-    devices.append(ttnn.open_device(device_id=device_id))
+# Open all available devices — use CreateDevices (not open_device in a loop,
+# which causes dispatch core errors on multi-device teardown)
+num_devices = ttnn.GetNumAvailableDevices()
+devices = ttnn.CreateDevices(list(range(num_devices)))
 
-# Create multi-device simulation
-sim = ParticleLifeMultiDevice(
-    devices=devices,  # List of device handles
-    num_particles=2048,
-    num_species=3
-)
+try:
+    # Create multi-device simulation
+    sim = ParticleLifeMultiDevice(
+        devices=devices,  # Dict of device_id → device handle
+        num_particles=2048,
+        num_species=3
+    )
 
-# Run with automatic parallelization
-history = sim.simulate(num_steps=500)
+    # Run with automatic parallelization
+    history = sim.simulate(num_steps=500)
+finally:
+    ttnn.CloseDevices(devices)
 ```
 
 ### Benchmark Results (4x p300c TT-QuietBox)
@@ -253,10 +261,10 @@ Real-world performance on TT-QuietBox Blackhole<sup>®</sup> Tower:
 cd ~/tt-scratchpad/cookbook/particle_life
 
 # Benchmark: Compare single vs multi-device
-python test_multi_device.py
+python3 test_multi_device.py
 
 # Direct multi-device run
-python particle_life_multi_device.py --multi-device
+python3 particle_life_multi_device.py --multi-device
 ```
 
 ### Why 50% Efficiency?
@@ -273,13 +281,13 @@ Try these experiments to push toward 3-4x speedup:
 
 ```bash
 # Larger workload (more particles per device)
-python particle_life_multi_device.py --multi-device --num-particles 4096 --num-steps 300
+python3 particle_life_multi_device.py --multi-device --num-particles 4096 --num-steps 300
 
 # More species (more complex interactions)
-python particle_life_multi_device.py --multi-device --species 7
+python3 particle_life_multi_device.py --multi-device --species 7
 
 # Longer simulation (amortize setup cost)
-python particle_life_multi_device.py --multi-device --num-steps 1000
+python3 particle_life_multi_device.py --multi-device --num-steps 1000
 ```
 
 ### Advanced: On-Device Force Calculations

--- a/content/lessons/deploy-to-koyeb.md
+++ b/content/lessons/deploy-to-koyeb.md
@@ -49,7 +49,7 @@ Deploy any Python application to Koyeb with Tenstorrent n300 hardware access. We
 From Lesson 7 (vLLM Production), you learned to run:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
+python3 -m vllm.entrypoints.openai.api_server \
   --model ~/models/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
   --port 8000
@@ -97,7 +97,7 @@ ENV MODEL_PATH=/home/coder/models/Qwen3-0.6B
 EXPOSE 8000
 
 # Run your app
-CMD ["/bin/bash", "-c", "source vllm/vllm-env/bin/activate && python -m vllm.entrypoints.openai.api_server --model ${MODEL_PATH} --served-model-name Qwen/Qwen3-0.6B --port 8000 --host 0.0.0.0"]
+CMD ["/bin/bash", "-c", "source vllm/vllm-env/bin/activate && python3 -m vllm.entrypoints.openai.api_server --model ${MODEL_PATH} --served-model-name Qwen/Qwen3-0.6B --port 8000 --host 0.0.0.0"]
 ```
 
 **Benefits:**
@@ -238,7 +238,7 @@ RUN cd app && \
 EXPOSE 5000
 
 # Run your app
-CMD ["/bin/bash", "-c", "cd app && source venv/bin/activate && python server.py"]
+CMD ["/bin/bash", "-c", "cd app && source venv/bin/activate && python3 server.py"]
 ```
 
 **Much simpler!** From 80 lines to 15 lines.
@@ -281,7 +281,7 @@ RUN python3 -m venv venv && \
     pip install torch ttnn numpy
 
 # Run processing script
-CMD ["/bin/bash", "-c", "source venv/bin/activate && python process.py"]
+CMD ["/bin/bash", "-c", "source venv/bin/activate && python3 process.py"]
 ```
 
 **Even simpler!** Just 13 lines total.

--- a/content/lessons/vllm-production.md
+++ b/content/lessons/vllm-production.md
@@ -262,7 +262,7 @@ Before proceeding, let's check what you already have installed:
 [ -d ~/tt-vllm ] && echo "✓ vLLM repo found" || echo "✗ vLLM repo missing"
 
 # Check if vLLM is importable from the active venv
-python3 -c "import vllm; print('✓ vLLM importable, version:', vllm.__version__)" 2>/dev/null \
+python3 -c "import vllm; print('✓ vLLM importable, version:', getattr(vllm, '__version__', '(unknown)'))" 2>/dev/null \
   || echo "✗ vLLM not importable — activate the vLLM venv first (see below)"
 
 # Check if server script exists
@@ -323,7 +323,7 @@ tt-vllm
 # source ~/.tenstorrent-venv/bin/activate
 # custom setup (script generated above):
 # source ~/activate-vllm-env.sh
-# or directly:
+# cloud / custom install:
 # source /opt/venv-vllm/bin/activate
 ```
 

--- a/content/lessons/vllm-production.md
+++ b/content/lessons/vllm-production.md
@@ -261,11 +261,9 @@ Before proceeding, let's check what you already have installed:
 # Check if vLLM is cloned
 [ -d ~/tt-vllm ] && echo "✓ vLLM repo found" || echo "✗ vLLM repo missing"
 
-# Check if venv exists (correct location integrated with tt-metal)
-[ -d ~/tt-metal/build/python_env_vllm ] && echo "✓ vLLM venv found" || echo "✗ vLLM venv missing"
-
-# Check if activation script exists
-[ -f ~/activate-vllm-env.sh ] && echo "✓ Activation script found" || echo "✗ Activation script missing"
+# Check if vLLM is importable from the active venv
+python3 -c "import vllm; print('✓ vLLM importable, version:', vllm.__version__)" 2>/dev/null \
+  || echo "✗ vLLM not importable — activate the vLLM venv first (see below)"
 
 # Check if server script exists
 [ -f ~/tt-scratchpad/start-vllm-server.py ] && echo "✓ Server script found" || echo "✗ Server script missing"
@@ -317,9 +315,16 @@ bash ~/tt-scratchpad/setup-vllm-env.sh
 
 **Time:** ~5-10 minutes (downloads + compilation)
 
-**After completion:**
+**After completion — activate the vLLM environment:**
 ```bash
-source ~/activate-vllm-env.sh
+# tt-developer-image / Docker:
+tt-vllm
+# QB2 pre-installed image:
+# source ~/.tenstorrent-venv/bin/activate
+# custom setup (script generated above):
+# source ~/activate-vllm-env.sh
+# or directly:
+# source /opt/venv-vllm/bin/activate
 ```
 
 ---
@@ -391,7 +396,7 @@ Just specify the model - everything else is auto-configured:
 
 ```bash
 # Minimal command (recommended):
-python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
+python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
 
 # Script automatically detects and configures:
 # Hardware Detection:
@@ -412,10 +417,10 @@ python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
 ```bash
 # Override hardware detection:
 export MESH_DEVICE=N300
-python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
+python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
 
 # Override defaults:
-python ~/tt-scratchpad/start-vllm-server.py \
+python3 ~/tt-scratchpad/start-vllm-server.py \
   --model ~/models/Qwen3-0.6B \
   --max-model-len 8192
 ```
@@ -466,8 +471,8 @@ Before starting the server, create the script that registers TT models with vLLM
 **✨ New in v0.0.101:** Ultra-simple one-command start with full hardware auto-detection!
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B
 ```
 
 **That's literally it!** The activation script sets up the environment and the starter script auto-detects and configures:
@@ -501,8 +506,8 @@ Now start vLLM with your chosen model and hardware configuration. These commands
 **Command (tested and working):**
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Qwen3-0.6B \
     --served-model-name Qwen/Qwen3-0.6B \
     --host 0.0.0.0 \
@@ -526,8 +531,8 @@ source ~/activate-vllm-env.sh && \
 **Alternative: Gemma 3-1B-IT** (slightly larger, 32K context)
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/gemma-3-1b-it \
     --served-model-name google/gemma-3-1b-it \
     --host 0.0.0.0 \
@@ -546,8 +551,8 @@ Llama-3.1-8B typically exhausts DRAM on n150. Use Qwen3-0.6B or Gemma 3-1B-IT in
 If you must try Llama on n150:
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Llama-3.1-8B-Instruct \
     --served-model-name meta-llama/Llama-3.1-8B-Instruct \
     --host 0.0.0.0 \
@@ -566,8 +571,8 @@ source ~/activate-vllm-env.sh && \
 ### n300 (Wormhole - Dual Chip)
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Llama-3.1-8B-Instruct \
     --served-model-name meta-llama/Llama-3.1-8B-Instruct \
     --host 0.0.0.0 \
@@ -585,8 +590,8 @@ source ~/activate-vllm-env.sh && \
 ### T3000 (Wormhole - 8 Chips)
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Llama-3.1-70B-Instruct \
     --served-model-name meta-llama/Llama-3.1-70B-Instruct \
     --host 0.0.0.0 \
@@ -608,8 +613,8 @@ source ~/activate-vllm-env.sh && \
 > **TT-QuietBox<sup>®</sup> 2 / TT-QuietBox users:** p300c is architecturally identical to p100. Use `MESH_DEVICE=P100` and `TT_METAL_ARCH_NAME=blackhole` for single-chip lessons. A TT-QuietBox 2 with 4× p300c = 4 independent single-chip devices; for most lessons use device 0 only.
 
 ```bash
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Llama-3.1-8B-Instruct \
     --served-model-name meta-llama/Llama-3.1-8B-Instruct \
     --host 0.0.0.0 \
@@ -719,8 +724,8 @@ INFO: Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
 # Stop the current server (Ctrl+C in the server terminal)
 
 # Start with Qwen instead
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Qwen3-8B \
     --host 0.0.0.0 \
     --port 8000 \
@@ -1023,7 +1028,7 @@ This is why Qwen3-0.6B punches way above its weight class!
 ### Custom Parameters
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
+python3 -m vllm.entrypoints.openai.api_server \
   --model meta-llama/Llama-3.1-8B-Instruct \
   --host 0.0.0.0 \
   --port 8000 \
@@ -1053,7 +1058,7 @@ export VLLM_LOGGING_LEVEL=DEBUG
 Simple deployment for moderate load:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
+python3 -m vllm.entrypoints.openai.api_server \
   --model $HF_MODEL \
   --host 0.0.0.0 \
   --port 8000
@@ -1070,7 +1075,7 @@ FROM tenstorrent/tt-metal:latest
 
 RUN pip install vllm
 
-CMD python -m vllm.entrypoints.openai.api_server \
+CMD python3 -m vllm.entrypoints.openai.api_server \
     --model meta-llama/Llama-3.1-8B-Instruct \
     --host 0.0.0.0 \
     --port 8000
@@ -1159,8 +1164,11 @@ Don't worry if you hit issues - they're usually straightforward to fix. Here are
 
 **Check your environment:**
 ```bash
-# Activate environment
-source ~/activate-vllm-env.sh
+# Activate vLLM environment (choose for your setup):
+tt-vllm                                           # tt-developer-image / Docker
+# source ~/.tenstorrent-venv/bin/activate         # QB2 pre-installed image
+# source ~/activate-vllm-env.sh                   # custom script-based setup
+# source /opt/venv-vllm/bin/activate              # cloud / custom install
 
 # Verify model path
 ls ~/models/Llama-3.1-8B-Instruct/config.json
@@ -1170,8 +1178,7 @@ ls ~/models/Llama-3.1-8B-Instruct/config.json
 This is the most common environment issue - wrong PyTorch version!
 
 ```bash
-# Check your PyTorch version
-source ~/activate-vllm-env.sh
+# Check your PyTorch version (activate vLLM env first — see above)
 python3 -c "import torch; print('PyTorch version:', torch.__version__)"
 ```
 
@@ -1199,7 +1206,7 @@ If larger models (8B params) exhaust your DRAM on n150, use smaller models:
   hf download Qwen/Qwen3-0.6B --local-dir ~/models/Qwen3-0.6B
 
   # Start server (use n150 command from Step 4 above)
-  python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B ...
+  python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/Qwen3-0.6B ...
 ```
 
 - **Gemma 3-1B-IT** - 1B params (8x smaller than 8B)
@@ -1208,7 +1215,7 @@ If larger models (8B params) exhaust your DRAM on n150, use smaller models:
   hf download google/gemma-3-1b-it --local-dir ~/models/gemma-3-1b-it
 
   # Start server (use n150 command from Step 4 above)
-  python ~/tt-scratchpad/start-vllm-server.py --model ~/models/gemma-3-1b-it ...
+  python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/gemma-3-1b-it ...
 ```
 
 **Why small models work better on n150:**
@@ -1247,8 +1254,8 @@ The `start-vllm-server.py` script now auto-detects p100 and sets `TT_METAL_ARCH_
 ```bash
 export TT_METAL_ARCH_NAME=blackhole
 export MESH_DEVICE=P100
-source ~/activate-vllm-env.sh && \
-  python ~/tt-scratchpad/start-vllm-server.py \
+# Activate vLLM env: tt-vllm  OR  source ~/.tenstorrent-venv/bin/activate  OR  source /opt/venv-vllm/bin/activate
+python3 ~/tt-scratchpad/start-vllm-server.py \
     --model ~/models/Llama-3.1-8B-Instruct
 ```
 
@@ -1258,7 +1265,7 @@ source ~/activate-vllm-env.sh && \
 This error means vLLM cannot find the TT model implementation. Solution:
 ```bash
 # Use the starter script (Step 4) which registers TT models
-python ~/tt-scratchpad/start-vllm-server.py --model ~/models/Llama-3.1-8B-Instruct
+python3 ~/tt-scratchpad/start-vllm-server.py --model ~/models/Llama-3.1-8B-Instruct
 ```
 
 **Why this happens:** vLLM needs to explicitly register TT models using `ModelRegistry.register_model()` before starting. The starter script does this automatically. Do NOT call `python -m vllm.entrypoints.openai.api_server` directly - it will fail because TT models aren't registered.
@@ -1623,8 +1630,8 @@ aider --model openai/meta-llama/Llama-3.2-3B-Instruct \
 pip install -r requirements.txt
 
 # Run the app
-python weather.py "San Francisco"
-python weather.py "Tokyo"
+python3 weather.py "San Francisco"
+python3 weather.py "Tokyo"
 ```
 
 ### Best Practices for AI-Assisted Coding
@@ -1723,7 +1730,7 @@ source ~/aider-venv/bin/activate
 pip install --upgrade aider-chat
 
 # Check Python version (must be 3.9+)
-python --version
+python3 --version
 ```
 
 ### Example Projects to Try

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.0.503",
+  "version": "0.0.504",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",


### PR DESCRIPTION
This pull request performs a comprehensive audit and update of all cookbook and deployment lessons to ensure compatibility with Ubuntu 24.04, the tt-developer-image, QB2 pre-installed images, and various cloud/custom installation environments. The main focus is on standardizing Python usage (moving from `python` to `python3`), updating virtual environment activation instructions for all supported setups, and fixing multi-device handling in the particle life lesson. Additionally, several vLLM production and deployment commands are modernized for robustness and clarity.

Key changes include:

**Python 3 Standardization Across Lessons**
- All code blocks, scripts, and command-line invocations in the cookbooks (`cookbook-game-of-life`, `cookbook-audio-processor`, `cookbook-mandelbrot`, `cookbook-image-filters`, `cookbook-particle-life`) and deployment lessons (`deploy-to-koyeb`, `vllm-production`) now use `python3` instead of `python` to ensure compatibility with Ubuntu 24.04 and the tt-developer-image, which no longer provide a `python` symlink. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R18) [[2]](diffhunk://#diff-5f18b30ef446fad75d27796d5de534f741b887b88eb609407690396efb293397L764-R769) [[3]](diffhunk://#diff-5f18b30ef446fad75d27796d5de534f741b887b88eb609407690396efb293397L774-R779) [[4]](diffhunk://#diff-5f18b30ef446fad75d27796d5de534f741b887b88eb609407690396efb293397L806-R811) [[5]](diffhunk://#diff-87654a46979c9aee22806ccb6c4d0b14e7a9bec0d512c48f5f4c62c06284d8a5R407-R422) [[6]](diffhunk://#diff-0f4fc791e92674c062d01af095d0286ac8960286820c3d40957573e288670bd2L328-R333) [[7]](diffhunk://#diff-8ec9fbe7fe1b3e87e0d8d8c04403bee1cae9fbe6d45cc6bfd29d2d4ec9261f63L536-R541) [[8]](diffhunk://#diff-61c286d492dff1e9f255eb846b52bb947b2754720cb28f8b6f35e6955bec7a72R89-R98) [[9]](diffhunk://#diff-61c286d492dff1e9f255eb846b52bb947b2754720cb28f8b6f35e6955bec7a72L256-R267) [[10]](diffhunk://#diff-61c286d492dff1e9f255eb846b52bb947b2754720cb28f8b6f35e6955bec7a72L276-R290) [[11]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L52-R52) [[12]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L100-R100) [[13]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L241-R241) [[14]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L284-R284) [[15]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL394-R399) [[16]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL415-R423) [[17]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL469-R475) [[18]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL504-R510) [[19]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL529-R535) [[20]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL549-R555) [[21]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL569-R575) [[22]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL588-R594)

**Virtual Environment Activation and Documentation Improvements**
- All lessons now clearly document how to activate the appropriate Python environment for each installation scenario, showing the `tt-metal` shell switcher (for tt-developer-image/Docker), `~/.tenstorrent-venv` (QB2 pre-installed), and `/opt/venv-metal` (cloud/custom) options. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R18) [[2]](diffhunk://#diff-5f18b30ef446fad75d27796d5de534f741b887b88eb609407690396efb293397R751-R755) [[3]](diffhunk://#diff-87654a46979c9aee22806ccb6c4d0b14e7a9bec0d512c48f5f4c62c06284d8a5R407-R422) [[4]](diffhunk://#diff-0f4fc791e92674c062d01af095d0286ac8960286820c3d40957573e288670bd2R318-R322) [[5]](diffhunk://#diff-8ec9fbe7fe1b3e87e0d8d8c04403bee1cae9fbe6d45cc6bfd29d2d4ec9261f63R510-R522) [[6]](diffhunk://#diff-61c286d492dff1e9f255eb846b52bb947b2754720cb28f8b6f35e6955bec7a72R89-R98) [[7]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL320-R327)

**Multi-Device Handling Fix in Particle Life Lesson**
- The multi-device "Key Code Pattern" in `cookbook-particle-life` is updated to use `ttnn.CreateDevices` and `ttnn.CloseDevices` for device management instead of looping over `open_device`, which previously caused dispatch core errors during teardown. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R18) [[2]](diffhunk://#diff-61c286d492dff1e9f255eb846b52bb947b2754720cb28f8b6f35e6955bec7a72L223-R244)

**vLLM Production and Deployment Robustness**
- The vLLM production lesson replaces the broken check for the venv directory with a direct import test (`python3 -c "import vllm"`), and all server launch instructions are updated to use the new multi-path activation pattern and `python3`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R18) [[2]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL264-R266) [[3]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL320-R327) [[4]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL394-R399) [[5]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL415-R423) [[6]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL469-R475) [[7]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL504-R510) [[8]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL529-R535) [[9]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL549-R555) [[10]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL569-R575) [[11]](diffhunk://#diff-dcefa5045f8deb0c076319ca60e2b853b045015d8ccabeb579c6fcaa0645191aL588-R594)

**Docker and Deployment Command Consistency**
- All Dockerfile `CMD` entries and deployment scripts in the lessons are updated to use `python3` instead of `python`, ensuring consistent behavior across platforms. [[1]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L100-R100) [[2]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L241-R241) [[3]](diffhunk://#diff-02f226a8d65490d853efec15189a4fe24b8731ca0c1720bfa35a12e11c3b7536L284-R284)

These changes collectively ensure a smooth, reproducible experience for users across all supported environments and hardware setups.