### PR TITLE
v0.1.18: address PRD-246 QB2 feedback + PR #43 post-release follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.1.18] - 2026-07-13
+### Fixed
+- **PRD-246 — Jeremy's QB2 testing feedback on the first-inference lesson flow:**
+  - `download-model` — fixed the broken "Step 3: Download the Model" skip link. The anchor pointed to `#step-3-download-qwen3-0-6b`, but the "Step 3: Download Qwen3-0.6B" heading slugs to `#step-3-download-qwen3-06b` (the `.` in `0.6B` is dropped, not turned into a hyphen).
+  - `download-model` — consolidated the repeated, scattered Hugging Face auth flow. Removed the standalone "Already Authenticated?" pre-check and folded the `hf auth whoami` check into Step 2, so authentication reads as a single sequence (set token → check → log in) instead of appearing in multiple places.
+  - `hardware-detection` — marked "Check 4: Device Reset" as optional; it is a recovery action, not part of normal detection, and a healthy device never needs it.
+  - `tt-installer` — removed the redundant `tt-smi` hardware-detection step from "Step 4: Verify Installation" (it duplicated the dedicated Hardware Detection lesson) and linked out to that lesson instead.
+  - `tt-installer` / `TEST_METALIUM_CONTAINER` — simplified the "Test TT-Metalium" button to the documented `tt-metalium "python3 -c 'import ttnn; print(ttnn.__version__)'"` form, dropping the fragile nested-quote/emoji f-string that could error. Added a TT-QuietBox 2 caveat noting the container test requires Podman plus the `tt-metalium` wrapper, which pre-built QB2 images may not include (verify TT-NN directly in that case).
+### Changed
+- **PR #43 post-release follow-ups (jzheng's non-blocking review notes):**
+  - `train_nano_from_scratch.py` — the docstring run example now uses `~/tt-metal/...` to match the code's `~/tt-metal` default. The code default was corrected in 0.1.17; the example in the header comment had lagged behind.
+  - Added regression coverage for the docs-site command-map parser (issue #42). Extracted the parser out of `build-web.js` into `scripts/lib/command-map-parser.js` as a pure function of two source strings, and added `test/lesson-tests/command-map-parser.test.ts`. The tests assert the function-boundary guard (a keyless file-opener must not inherit the next handler's command), plus single/double/backtick/multi-line template extraction and digit-bearing keys.
+
 ## [0.1.17] - 2026-07-10
 ### Fixed
 - **Addressed PR #43 review feedback:**

--- a/README.md
+++ b/README.md
@@ -408,7 +408,14 @@ We welcome contributions! Here's how to get involved:
 
 ## Release Information
 
-### Latest Release: v0.1.17 (2026-07-10)
+### Latest Release: v0.1.18 (2026-07-13)
+
+**Highlights:**
+- 🐛 **PRD-246 first-inference flow fixes (from QB2 testing)** — fixed the broken "Step 3: Download the Model" skip link, consolidated the scattered Hugging Face auth flow into one sequence, marked the device-reset check optional, dropped the redundant `tt-smi` step from the installer lesson, and simplified the "Test TT-Metalium" button (with a QB2/Podman caveat)
+- ✅ **Regression test for the docs-site command parser (issue #42)** — extracted the parser into a pure module and added tests that lock in the function-boundary guard so a keyless file-opener can never again inherit the next command's template
+- 🧹 **PR #43 follow-up** — `train_nano_from_scratch.py` docstring example now matches the `~/tt-metal` code default
+
+### Previous Release: v0.1.17 (2026-07-10)
 
 **Highlights:**
 - 🔧 **PR #43 review fixes** — robust `ttml` `.pth` wiring (venv-safe site-packages + `build_Release` path), export-aware docs-site command parser, `~/tt-metal` default in the from-scratch scaffold, and doc/version alignment
@@ -421,7 +428,7 @@ We welcome contributions! Here's how to get involved:
 - 📌 **Version floors aligned to the verified reality** — `ct4`/`ct8` raised to `minTTMetalVersion: v0.73.1` in both markdown and the registry
 - 🩹 **`ct8` troubleshooting enriched** with real four-chip-run gotchas (fabric/MGD timeout, device contention, DDP checkpoint-save, broken auto-resume, decoder looping)
 
-### Previous Release: v0.1.9 (2026-07-09)
+### Earlier: v0.1.9 (2026-07-09)
 
 **Highlights:**
 - ✅ **ct5 (Multi-Device Training) flipped to `validated`** — multi-chip `tt-train` DDP verified working on a TT-QuietBox<sup>®</sup> 2, with near-linear scaling to 4 Blackhole<sup>®</sup> chips (1.95× at 2 chips, 3.98× at 4 chips)

--- a/content/lessons/download-model.md
+++ b/content/lessons/download-model.md
@@ -67,21 +67,6 @@ which hf || pip install huggingface-hub
 
 ---
 
-### Already Authenticated?
-
-Check if you're already logged in to Hugging Face:
-
-```bash
-hf auth whoami
-```
-
-**If this shows your username:** You're already authenticated! Skip to
-[Step 3: Download the Model](#step-3-download-qwen3-0-6b).
-
-**If it shows an error:** Continue with Step 1 below to authenticate.
-
----
-
 ### Model Already Downloaded?
 
 Check if Qwen3-0.6B is already present:
@@ -160,7 +145,16 @@ source ~/.bashrc
 
 ## Step 2: Authenticate
 
-Once your token is set, authenticate with Hugging Face:
+**First, check whether you're already logged in:**
+
+```bash
+hf auth whoami
+```
+
+**If this prints your username:** you're authenticated — skip straight to
+[Step 3: Download the Model](#step-3-download-qwen3-06b).
+
+**If it shows an error:** log in with the token you set in Step 1:
 
 ```bash
 hf auth login --token "$HF_TOKEN"

--- a/content/lessons/hardware-detection.md
+++ b/content/lessons/hardware-detection.md
@@ -251,7 +251,11 @@ sudo usermod -a -G tenstorrent $USER
 # Log out and back in for group changes to take effect
 ```
 
-### Check 4: Device Reset
+### Check 4 (Optional): Device Reset
+
+> **Optional — recovery step only.** Skip this unless a device shows up in
+> `tt-smi` but reports errors or won't initialize. A healthy device does not
+> need a reset.
 
 **If device appears but shows errors:**
 ```bash

--- a/content/lessons/tt-installer.md
+++ b/content/lessons/tt-installer.md
@@ -171,22 +171,11 @@ For automated deployments or cloud environments, use non-interactive mode:
 
 ## Step 4: Verify Installation
 
-After installation (and reboot if prompted), verify everything works:
+After installation (and reboot if prompted), confirm the pieces are in place.
 
-### Check Hardware Detection
-
-```bash
-tt-smi
-```
-
-You should see your Tenstorrent device(s) listed with:
-- Board Type (n150, n300, T3000, etc.)
-- PCI Bus ID
-- Firmware version
-- Temperature
-- Power draw
-
-[🔍 Run tt-smi](command:tenstorrent.runHardwareDetection)
+**Detecting your hardware** (`tt-smi`) is covered in depth in the next lesson —
+see [Hardware Detection](command:tenstorrent.showLesson?["hardware-detection"]).
+Once that shows your device, come back and test the container below.
 
 ### Test TT-Metalium Container
 
@@ -200,6 +189,15 @@ This verifies:
 - ✅ Container launches successfully
 - ✅ TT-NN library is available
 - ✅ Python environment is configured
+
+> **⚠️ TT-QuietBox 2 (and other pre-configured images):** this test needs the
+> TT-Metalium **container** (Podman + the `tt-metalium` wrapper) that the
+> installer sets up. Pre-built QB2 images ship TT-NN and vLLM directly but may
+> **not** include Podman or the container wrapper — in that case `tt-metalium`
+> won't be found. Verify TT-NN directly instead:
+> ```bash
+> python3 -c 'import ttnn; print(ttnn.__version__)'
+> ```
 
 [🧪 Test TT-Metalium](command:tenstorrent.testMetaliumContainer)
 

--- a/content/templates/llm-from-scratch/train_nano_from_scratch.py
+++ b/content/templates/llm-from-scratch/train_nano_from_scratch.py
@@ -41,7 +41,7 @@
 # Run (Blackhole p300c):
 #
 #     python content/templates/llm-from-scratch/train_nano_from_scratch.py \
-#         --max_steps 20 --data_path /home/ttuser/tt-metal/tt-train/data/shakespeare.txt
+#         --max_steps 20 --data_path ~/tt-metal/tt-train/data/shakespeare.txt
 #
 # (Arch resolution: an explicit --arch always wins; otherwise the runner
 #  honours an already-exported TT_METAL_ARCH_NAME; otherwise it defaults to

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tt-vscode-toolkit",
   "displayName": "TT Developer Toolkit",
   "description": "Interactive lessons, hardware monitoring, and production templates for AI silicon development",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "icon": "dist/assets/img/marketplace-icon.png",
   "galleryBanner": {
     "color": "#1e1e2e",

--- a/scripts/build-web.js
+++ b/scripts/build-web.js
@@ -33,6 +33,7 @@ const { markedHighlight } = require('marked-highlight');
 const matter              = require('gray-matter');
 const DOMPurify           = require('isomorphic-dompurify');
 const sanitizeHtml        = require('sanitize-html');
+const { buildCommandMap } = require('./lib/command-map-parser');
 
 /* ------------------------------------------------------------------ *
  * Paths                                                               *
@@ -72,6 +73,7 @@ const STYLES_DIR      = path.join(ROOT, 'src', 'webview', 'styles');
 const SCRIPTS_DIR     = path.join(ROOT, 'src', 'webview', 'scripts');
 const ASSETS_IMG_DIR  = path.join(ROOT, 'assets', 'img');
 const TERM_CMDS_PATH  = path.join(ROOT, 'src', 'commands', 'terminalCommands.ts');
+const EXTENSION_PATH  = path.join(ROOT, 'src', 'extension.ts');
 const MERMAID_SRC     = path.join(ROOT, 'node_modules', 'mermaid', 'dist', 'mermaid.min.js');
 
 /* ------------------------------------------------------------------ *
@@ -183,130 +185,13 @@ const lessons  = registry.lessons || [];
  * Extracts: KEY: { ... template: `command text` ... }                 *
  * ------------------------------------------------------------------ */
 
-function buildCommandMap() {
-  const src = fs.readFileSync(TERM_CMDS_PATH, 'utf8');
-  const map = {};
-
-  // terminalCommands.ts uses two quoting styles for template values:
-  //
-  //   Simple single-line commands:   template: 'pip install flask',
-  //   Multi-line / interpolated:     template: `cd ~/code && ...`,
-  //
-  // We walk line by line, tracking the current KEY name, then extract
-  // the template value regardless of which quote style is used.
-  let currentKey = null;
-  // Keys can contain digits (e.g. START_TT_INFERENCE_SERVER_N150, DOWNLOAD_WAN22_MODEL).
-  const keyRe = /^\s{2}([A-Z][A-Z0-9_]*):\s*\{/;
-  const lines = src.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Detect a new top-level KEY: { block
-    const keyMatch = line.match(keyRe);
-    if (keyMatch) {
-      currentKey = keyMatch[1];
-    }
-
-    if (!currentKey) continue;
-
-    // ---- single-quoted single-line:  template: 'text',
-    const sqMatch = line.match(/template:\s*'([^']+)'/);
-    if (sqMatch) {
-      map[currentKey] = sqMatch[1];
-      currentKey = null;
-      continue;
-    }
-
-    // ---- double-quoted single-line:  template: "text",
-    const dqMatch = line.match(/template:\s*"([^"]+)"/);
-    if (dqMatch) {
-      map[currentKey] = dqMatch[1];
-      currentKey = null;
-      continue;
-    }
-
-    // ---- backtick single-line:  template: `text`,
-    const btMatch = line.match(/template:\s*`([^`]+)`/);
-    if (btMatch) {
-      map[currentKey] = btMatch[1];
-      currentKey = null;
-      continue;
-    }
-
-    // ---- backtick multi-line:  template: `first line
-    //                                        ...
-    //                                        last line`,
-    const btOpen = line.indexOf('template: `');
-    if (btOpen !== -1) {
-      let text = line.slice(btOpen + 'template: `'.length);
-      while (!text.includes('`') && i < lines.length - 1) {
-        i++;
-        text += '\n' + lines[i];
-      }
-      map[currentKey] = text.slice(0, text.lastIndexOf('`'));
-      currentKey = null;
-    }
-  }
-  // --- Second pass: parse extension.ts to build a direct camelCase suffix →
-  //     template mapping for commands that don't follow the simple
-  //     camelToUpperSnake naming convention.
-  //
-  //     Pattern in extension.ts:
-  //       async function createApiServerDirect() {
-  //         ...
-  //         const command = TERMINAL_COMMANDS.CREATE_API_SERVER.template;
-  //         ...
-  //       }
-  //       ...
-  //       registerCommand('tenstorrent.createApiServerDirect', createApiServerDirect)
-  //
-  //     We build:
-  //       funcName → TERMINAL_COMMANDS.KEY  (from function bodies)
-  //       commandSuffix → funcName           (from registerCommand calls)
-  //     Then join: commandSuffix → template
-
-  const EXTENSION_PATH = path.join(ROOT, 'src', 'extension.ts');
-  if (fs.existsSync(EXTENSION_PATH)) {
-    const extSrc = fs.readFileSync(EXTENSION_PATH, 'utf8');
-
-    // Map: funcName → TERMINAL_COMMANDS key (first occurrence wins).
-    // The body scan is tempered to stop at the next top-level function declaration —
-    // `function`, `async function`, or `export [async] function` (e.g. `export async
-    // function activate(...)`) — so a function with NO TERMINAL_COMMANDS reference (e.g. a
-    // file-opener like openRiscvKernel) can't "steal" a later function's key. That
-    // bleed-through was rendering a game-of-life command under CS-Fundamentals'
-    // "Open Kernel Source" (issue #42).
-    // Keys can contain digits (START_TT_INFERENCE_SERVER_N150, RUN_ANIMATEDIFF_2FRAME, …).
-    const funcToKey = {};
-    const funcKeyRe = /(?:export\s+)?(?:async\s+)?function\s+(\w+)[^{]*\{(?:(?!\n(?:export )?(?:async )?function )[\s\S])*?TERMINAL_COMMANDS\.([A-Z0-9_]+)\./g;
-    let fkMatch;
-    while ((fkMatch = funcKeyRe.exec(extSrc)) !== null) {
-      const funcName = fkMatch[1];
-      const tcKey    = fkMatch[2];
-      if (!funcToKey[funcName] && map[tcKey]) {
-        funcToKey[funcName] = tcKey;
-      }
-    }
-
-    // Map: tenstorrent.commandSuffix → funcName (from registerCommand calls)
-    const regRe = /registerCommand\(['"]tenstorrent\.(\w+)['"]\s*,\s*(\w+)/g;
-    let regMatch;
-    while ((regMatch = regRe.exec(extSrc)) !== null) {
-      const suffix   = regMatch[1];
-      const funcName = regMatch[2];
-      if (funcToKey[funcName]) {
-        // Store as suffix → template under a special prefix so commandTextForId
-        // can find it directly without the camelToUpperSnake conversion.
-        map['__ext__' + suffix] = map[funcToKey[funcName]];
-      }
-    }
-  }
-
-  return map;
-}
-
-const COMMAND_MAP = buildCommandMap();
+// Parse terminalCommands.ts + extension.ts into a command-text map. The parser
+// itself lives in ./lib/command-map-parser.js as a pure function so the issue
+// #42 boundary-guard fix can be regression-tested with fixtures.
+const COMMAND_MAP = buildCommandMap(
+  fs.readFileSync(TERM_CMDS_PATH, "utf8"),
+  fs.existsSync(EXTENSION_PATH) ? fs.readFileSync(EXTENSION_PATH, "utf8") : ""
+);
 
 // Also build a camelCase → KEY lookup so we can resolve
 // tenstorrent.cloneTtLocalGenerator → CLONE_TT_LOCAL_GENERATOR

--- a/scripts/lib/command-map-parser.js
+++ b/scripts/lib/command-map-parser.js
@@ -19,6 +19,26 @@
  *  @param {string} [extSrc] Contents of src/extension.ts (optional)
  *  @returns {Object<string,string>} map of KEY / "__ext__<suffix>" → command text
  */
+/**
+ * Decode the backslash escapes a JS/TS single- or double-quoted string literal
+ * would apply at runtime, so a source template like `'a \'b\' c'` maps to the
+ * actual command text `a 'b' c`. Done with a targeted replace (NOT eval) so we
+ * never execute source-derived strings.
+ *
+ * @param {string} raw  Captured literal body (contents between the quotes)
+ * @returns {string}
+ */
+function unescapeStringLiteral(raw) {
+  return raw.replace(/\\(['"\\nrt])/g, (_match, ch) => {
+    switch (ch) {
+      case 'n': return '\n';
+      case 'r': return '\r';
+      case 't': return '\t';
+      default:  return ch; // ' " \  → drop the leading backslash
+    }
+  });
+}
+
 function buildCommandMap(termSrc, extSrc) {
   const map = {};
 
@@ -46,15 +66,11 @@ function buildCommandMap(termSrc, extSrc) {
     if (!currentKey) continue;
 
     // ---- single-quoted single-line:  template: 'text',
-    // Capture escaped quotes/backslashes so templates containing \\' or \\" don't get truncated.
+    // The `(?:\\.|[^'])*` body matches escaped chars (e.g. \' \\) as a unit so a
+    // template containing an escaped quote isn't truncated at the first inner quote.
     const sqMatch = line.match(/template:\s*'((?:\\.|[^'])*)'/);
     if (sqMatch) {
-      try {
-        // Decode JS/TS string-literal escapes (e.g. \\n, \\', \\\\) to match runtime command text.
-        map[currentKey] = Function('"use strict"; return \' + sqMatch[1] + '\';')();
-      } catch (_) {
-        map[currentKey] = sqMatch[1];
-      }
+      map[currentKey] = unescapeStringLiteral(sqMatch[1]);
       currentKey = null;
       continue;
     }
@@ -62,11 +78,7 @@ function buildCommandMap(termSrc, extSrc) {
     // ---- double-quoted single-line:  template: "text",
     const dqMatch = line.match(/template:\s*"((?:\\.|[^"])*)"/);
     if (dqMatch) {
-      try {
-        map[currentKey] = Function('"use strict"; return "' + dqMatch[1] + '";')();
-      } catch (_) {
-        map[currentKey] = dqMatch[1];
-      }
+      map[currentKey] = unescapeStringLiteral(dqMatch[1]);
       currentKey = null;
       continue;
     }

--- a/scripts/lib/command-map-parser.js
+++ b/scripts/lib/command-map-parser.js
@@ -46,17 +46,27 @@ function buildCommandMap(termSrc, extSrc) {
     if (!currentKey) continue;
 
     // ---- single-quoted single-line:  template: 'text',
-    const sqMatch = line.match(/template:\s*'([^']+)'/);
+    // Capture escaped quotes/backslashes so templates containing \\' or \\" don't get truncated.
+    const sqMatch = line.match(/template:\s*'((?:\\.|[^'])*)'/);
     if (sqMatch) {
-      map[currentKey] = sqMatch[1];
+      try {
+        // Decode JS/TS string-literal escapes (e.g. \\n, \\', \\\\) to match runtime command text.
+        map[currentKey] = Function('"use strict"; return \' + sqMatch[1] + '\';')();
+      } catch (_) {
+        map[currentKey] = sqMatch[1];
+      }
       currentKey = null;
       continue;
     }
 
     // ---- double-quoted single-line:  template: "text",
-    const dqMatch = line.match(/template:\s*"([^"]+)"/);
+    const dqMatch = line.match(/template:\s*"((?:\\.|[^"])*)"/);
     if (dqMatch) {
-      map[currentKey] = dqMatch[1];
+      try {
+        map[currentKey] = Function('"use strict"; return "' + dqMatch[1] + '";')();
+      } catch (_) {
+        map[currentKey] = dqMatch[1];
+      }
       currentKey = null;
       continue;
     }

--- a/scripts/lib/command-map-parser.js
+++ b/scripts/lib/command-map-parser.js
@@ -1,0 +1,141 @@
+'use strict';
+
+/*
+ * ────────────────────────────────────────────────────────────────────────────
+ *  Command-map parser (extracted from build-web.js)
+ * ────────────────────────────────────────────────────────────────────────────
+ *
+ *  The docs-site generator needs the actual terminal-command text behind each
+ *  `command:tenstorrent.*` link so it can render a runnable snippet. Rather than
+ *  importing the extension's TypeScript at build time, we parse the two source
+ *  files with regexes.
+ *
+ *  This logic lives in its own module (as a PURE function of two source strings)
+ *  so the issue #42 fix — the function-boundary "bleed-through" guard — can be
+ *  regression-tested with fixtures, without executing the full site build.
+ *  See test/lesson-tests/command-map-parser.test.ts.
+ *
+ *  @param {string} termSrc  Contents of src/commands/terminalCommands.ts
+ *  @param {string} [extSrc] Contents of src/extension.ts (optional)
+ *  @returns {Object<string,string>} map of KEY / "__ext__<suffix>" → command text
+ */
+function buildCommandMap(termSrc, extSrc) {
+  const map = {};
+
+  // terminalCommands.ts uses two quoting styles for template values:
+  //
+  //   Simple single-line commands:   template: 'pip install flask',
+  //   Multi-line / interpolated:     template: `cd ~/code && ...`,
+  //
+  // We walk line by line, tracking the current KEY name, then extract
+  // the template value regardless of which quote style is used.
+  let currentKey = null;
+  // Keys can contain digits (e.g. START_TT_INFERENCE_SERVER_N150, DOWNLOAD_WAN22_MODEL).
+  const keyRe = /^\s{2}([A-Z][A-Z0-9_]*):\s*\{/;
+  const lines = termSrc.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Detect a new top-level KEY: { block
+    const keyMatch = line.match(keyRe);
+    if (keyMatch) {
+      currentKey = keyMatch[1];
+    }
+
+    if (!currentKey) continue;
+
+    // ---- single-quoted single-line:  template: 'text',
+    const sqMatch = line.match(/template:\s*'([^']+)'/);
+    if (sqMatch) {
+      map[currentKey] = sqMatch[1];
+      currentKey = null;
+      continue;
+    }
+
+    // ---- double-quoted single-line:  template: "text",
+    const dqMatch = line.match(/template:\s*"([^"]+)"/);
+    if (dqMatch) {
+      map[currentKey] = dqMatch[1];
+      currentKey = null;
+      continue;
+    }
+
+    // ---- backtick single-line:  template: `text`,
+    const btMatch = line.match(/template:\s*`([^`]+)`/);
+    if (btMatch) {
+      map[currentKey] = btMatch[1];
+      currentKey = null;
+      continue;
+    }
+
+    // ---- backtick multi-line:  template: `first line
+    //                                        ...
+    //                                        last line`,
+    const btOpen = line.indexOf('template: `');
+    if (btOpen !== -1) {
+      let text = line.slice(btOpen + 'template: `'.length);
+      while (!text.includes('`') && i < lines.length - 1) {
+        i++;
+        text += '\n' + lines[i];
+      }
+      map[currentKey] = text.slice(0, text.lastIndexOf('`'));
+      currentKey = null;
+    }
+  }
+
+  // --- Second pass: parse extension.ts to build a direct camelCase suffix →
+  //     template mapping for commands that don't follow the simple
+  //     camelToUpperSnake naming convention.
+  //
+  //     Pattern in extension.ts:
+  //       async function createApiServerDirect() {
+  //         ...
+  //         const command = TERMINAL_COMMANDS.CREATE_API_SERVER.template;
+  //         ...
+  //       }
+  //       ...
+  //       registerCommand('tenstorrent.createApiServerDirect', createApiServerDirect)
+  //
+  //     We build:
+  //       funcName → TERMINAL_COMMANDS.KEY  (from function bodies)
+  //       commandSuffix → funcName           (from registerCommand calls)
+  //     Then join: commandSuffix → template
+  if (extSrc) {
+    // Map: funcName → TERMINAL_COMMANDS key (first occurrence wins).
+    // The body scan is tempered to stop at the next top-level function declaration —
+    // `function`, `async function`, or `export [async] function` (e.g. `export async
+    // function activate(...)`) — so a function with NO TERMINAL_COMMANDS reference (e.g. a
+    // file-opener like openRiscvKernel) can't "steal" a later function's key. That
+    // bleed-through was rendering a game-of-life command under CS-Fundamentals'
+    // "Open Kernel Source" (issue #42).
+    // Keys can contain digits (START_TT_INFERENCE_SERVER_N150, RUN_ANIMATEDIFF_2FRAME, …).
+    const funcToKey = {};
+    const funcKeyRe = /(?:export\s+)?(?:async\s+)?function\s+(\w+)[^{]*\{(?:(?!\n(?:export )?(?:async )?function )[\s\S])*?TERMINAL_COMMANDS\.([A-Z0-9_]+)\./g;
+    let fkMatch;
+    while ((fkMatch = funcKeyRe.exec(extSrc)) !== null) {
+      const funcName = fkMatch[1];
+      const tcKey    = fkMatch[2];
+      if (!funcToKey[funcName] && map[tcKey]) {
+        funcToKey[funcName] = tcKey;
+      }
+    }
+
+    // Map: tenstorrent.commandSuffix → funcName (from registerCommand calls)
+    const regRe = /registerCommand\(['"]tenstorrent\.(\w+)['"]\s*,\s*(\w+)/g;
+    let regMatch;
+    while ((regMatch = regRe.exec(extSrc)) !== null) {
+      const suffix   = regMatch[1];
+      const funcName = regMatch[2];
+      if (funcToKey[funcName]) {
+        // Store as suffix → template under a special prefix so commandTextForId
+        // can find it directly without the camelToUpperSnake conversion.
+        map['__ext__' + suffix] = map[funcToKey[funcName]];
+      }
+    }
+  }
+
+  return map;
+}
+
+module.exports = { buildCommandMap };

--- a/src/commands/terminalCommands.ts
+++ b/src/commands/terminalCommands.ts
@@ -124,7 +124,7 @@ export const TERMINAL_COMMANDS: Record<string, CommandTemplate> = {
   TEST_METALIUM_CONTAINER: {
     id: 'test-metalium-container',
     name: 'Test tt-metalium Container',
-    template: 'tt-metalium "python3 -c \'import ttnn; print(f\\"TTNN version: {ttnn.__version__}\\"); print(\\"✅ tt-metalium container working!\\")\'"',
+    template: 'tt-metalium "python3 -c \'import ttnn; print(ttnn.__version__)\'"',
     description: 'Verifies tt-metalium container is installed and TTNN is accessible',
   },
 

--- a/test/lesson-tests/command-map-parser.test.ts
+++ b/test/lesson-tests/command-map-parser.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Command-Map Parser Tests
+ *
+ * Regression coverage for scripts/lib/command-map-parser.js — the docs-site
+ * generator's parser that maps `command:tenstorrent.*` links to their terminal
+ * command text.
+ *
+ * The headline case is issue #42: a function with NO `TERMINAL_COMMANDS`
+ * reference (e.g. a file-opener) must not "bleed through" and steal the key of
+ * the NEXT function during the body scan. Before the fix, that rendered a
+ * game-of-life command under CS-Fundamentals' "Open Kernel Source" button.
+ *
+ * These are pure-function tests over fixture strings — no VSCode, no disk, no
+ * full site build — so they run under plain `npm test`.
+ */
+
+import { expect } from 'chai';
+
+// Pure JS module (CommonJS) — required at runtime, no TS compilation needed.
+const { buildCommandMap } = require('../../scripts/lib/command-map-parser');
+
+describe('command-map parser', () => {
+  describe('terminalCommands.ts template extraction', () => {
+    it('extracts single-quoted, double-quoted, and backtick templates', () => {
+      const term = [
+        'export const TERMINAL_COMMANDS = {',
+        '  SINGLE_QUOTED: {',
+        "    template: 'tt-smi',",
+        '  },',
+        '  DOUBLE_QUOTED: {',
+        '    template: "podman info",',
+        '  },',
+        '  BACKTICK_INLINE: {',
+        '    template: `cd ~ && ./install.sh`,',
+        '  },',
+        '};',
+      ].join('\n');
+
+      const map = buildCommandMap(term);
+      expect(map.SINGLE_QUOTED).to.equal('tt-smi');
+      expect(map.DOUBLE_QUOTED).to.equal('podman info');
+      expect(map.BACKTICK_INLINE).to.equal('cd ~ && ./install.sh');
+    });
+
+    it('extracts multi-line backtick templates', () => {
+      const term = [
+        'export const TERMINAL_COMMANDS = {',
+        '  MULTILINE: {',
+        '    template: `line one',
+        'line two',
+        'line three`,',
+        '  },',
+        '};',
+      ].join('\n');
+
+      const map = buildCommandMap(term);
+      expect(map.MULTILINE).to.equal('line one\nline two\nline three');
+    });
+
+    it('handles keys containing digits', () => {
+      const term = [
+        'export const TERMINAL_COMMANDS = {',
+        '  START_SERVER_N150: {',
+        "    template: 'start n150',",
+        '  },',
+        '  RUN_ANIMATEDIFF_2FRAME: {',
+        "    template: 'run 2frame',",
+        '  },',
+        '};',
+      ].join('\n');
+
+      const map = buildCommandMap(term);
+      expect(map.START_SERVER_N150).to.equal('start n150');
+      expect(map.RUN_ANIMATEDIFF_2FRAME).to.equal('run 2frame');
+    });
+  });
+
+  describe('extension.ts function → command resolution (issue #42)', () => {
+    const term = [
+      'export const TERMINAL_COMMANDS = {',
+      '  GAME_OF_LIFE: {',
+      "    template: 'python3 game_of_life.py',",
+      '  },',
+      '};',
+    ].join('\n');
+
+    it('maps a command suffix to the template used in its handler', () => {
+      const ext = [
+        'function runGameOfLife() {',
+        '  const command = TERMINAL_COMMANDS.GAME_OF_LIFE.template;',
+        '  runInTerminal(command);',
+        '}',
+        "registerCommand('tenstorrent.runGameOfLife', runGameOfLife);",
+      ].join('\n');
+
+      const map = buildCommandMap(term, ext);
+      expect(map['__ext__runGameOfLife']).to.equal('python3 game_of_life.py');
+    });
+
+    it('does NOT let a keyless function steal the next function\'s key', () => {
+      // openKernelSource has no TERMINAL_COMMANDS reference. Before the boundary
+      // guard, its body scan bled into runGameOfLife and grabbed GAME_OF_LIFE.
+      const ext = [
+        'function openKernelSource() {',
+        "  const uri = vscode.Uri.file('/path/to/kernel.cpp');",
+        '  vscode.window.showTextDocument(uri);',
+        '}',
+        'function runGameOfLife() {',
+        '  const command = TERMINAL_COMMANDS.GAME_OF_LIFE.template;',
+        '  runInTerminal(command);',
+        '}',
+        "registerCommand('tenstorrent.openKernelSource', openKernelSource);",
+        "registerCommand('tenstorrent.runGameOfLife', runGameOfLife);",
+      ].join('\n');
+
+      const map = buildCommandMap(term, ext);
+      // The regression: the file-opener must NOT resolve to a command.
+      expect(map['__ext__openKernelSource']).to.be.undefined;
+      // ...and the real handler still resolves correctly.
+      expect(map['__ext__runGameOfLife']).to.equal('python3 game_of_life.py');
+    });
+
+    it('respects `export async function` boundaries too', () => {
+      const ext = [
+        'export async function openKernelSource() {',
+        "  await vscode.window.showTextDocument(vscode.Uri.file('/k.cpp'));",
+        '}',
+        'export async function runGameOfLife() {',
+        '  const command = TERMINAL_COMMANDS.GAME_OF_LIFE.template;',
+        '  runInTerminal(command);',
+        '}',
+        "registerCommand('tenstorrent.openKernelSource', openKernelSource);",
+        "registerCommand('tenstorrent.runGameOfLife', runGameOfLife);",
+      ].join('\n');
+
+      const map = buildCommandMap(term, ext);
+      expect(map['__ext__openKernelSource']).to.be.undefined;
+      expect(map['__ext__runGameOfLife']).to.equal('python3 game_of_life.py');
+    });
+
+    it('omits the extension pass when no extension source is provided', () => {
+      const map = buildCommandMap(term);
+      expect(map.GAME_OF_LIFE).to.equal('python3 game_of_life.py');
+      expect(Object.keys(map).some((k) => k.startsWith('__ext__'))).to.equal(false);
+    });
+  });
+});

--- a/test/lesson-tests/command-map-parser.test.ts
+++ b/test/lesson-tests/command-map-parser.test.ts
@@ -42,6 +42,21 @@ describe('command-map parser', () => {
       expect(map.BACKTICK_INLINE).to.equal('cd ~ && ./install.sh');
     });
 
+    it('decodes escaped quotes and escaped newlines in quoted templates', () => {
+      const term = [
+        'export const TERMINAL_COMMANDS = {',
+        '  ESCAPED: {',
+        "    template: 'tt-metalium \"python3 -c \\\'import ttnn; print(ttnn.__version__)\\\'\"\\nsecond line',",
+        '  },',
+        '};',
+      ].join('\n');
+
+      const map = buildCommandMap(term);
+      expect(map.ESCAPED).to.equal(
+        'tt-metalium "python3 -c \'import ttnn; print(ttnn.__version__)\'"\nsecond line'
+      );
+    });
+
     it('extracts multi-line backtick templates', () => {
       const term = [
         'export const TERMINAL_COMMANDS = {',


### PR DESCRIPTION
PRD-246 (Jeremy's QB2 lesson testing):
- download-model: fix broken "Step 3" skip link (anchor slug bug); consolidate the scattered Hugging Face auth flow into one Step 1->Step 2 sequence
- hardware-detection: mark "Check 4: Device Reset" as optional (recovery only)
- tt-installer: drop redundant tt-smi step from Verify Installation (link to the Hardware Detection lesson); simplify the "Test TT-Metalium" button command and add a QB2/Podman container caveat with a host-native TT-NN fallback

PR #43 post-release follow-ups (jzheng's non-blocking notes):
- train_nano_from_scratch.py: docstring example now matches the ~/tt-metal default
- extract the docs-site command-map parser into scripts/lib/command-map-parser.js as a pure function and add regression tests locking in the issue #42 function-boundary guard, quote styles, and digit-bearing keys

